### PR TITLE
Add a unified glossary.

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,0 +1,278 @@
+==================
+Terms and concepts
+==================
+
+Concepts and terminology may overlap with existing technologies,
+whereas the requirements specified here are intended to be agnostic to specific solutions.
+This document assumes the following definitions of potentially overloaded key words.
+
+.. glossary::
+
+    task
+        The smallest divisible unit of work representable within the API.
+        Generally an :term:`operation` or a portion of an operation that has
+        been decomposed in terms of decoupled parallelism or execution checkpoint
+        interval.
+
+    work
+        A task or tasks, packaged for dispatching and execution.
+
+    worker
+        The unit of allocation of runtime computing resources. Should not be
+        relevant to the user, but may figure into the implementation details of
+        task dispatching.
+
+    graph
+    work graph
+        A directed acyclic graph of operation nodes connected by data flow edges.
+
+    graph state
+        The aggregation of state for nodes and edges, constrained by directed
+        acyclic data flow topology. Granularity is not yet fully determined, but
+        state must account for completed and incomplete operations, and allow
+        distinction between idle and currently executing nodes.
+
+These two terms are borrowed from TensorFlow:
+
+.. glossary::
+
+    Context
+      Abstraction for the entity that maps work to a computing environment.
+
+    Session
+      Abstraction for the entity representing work that is executing on resources
+      allocated by an instance of a Context implementation.
+
+The above terms roughly map to terms like *Executor* and *Task* in other frameworks.
+Distinctions relate to the lifetime of the :term:`Context` instance, and the fact that
+it owns both the work specification (including operation and data handles)
+and the computing resources.
+The :term:`Context` instance owns resources (on behalf of the client) that may
+otherwise be owned directly by the client, and so its lifetime must span all
+references to resources, operation handles, and data futures.
+
+.. glossary::
+
+    operation
+        A well defined computational element or data transformation that can be used
+        to add computational work to a graph managed by a Context. Operation inputs
+        are strongly specified, and behavior for a given set of inputs is deterministic
+        (within numerical stability). Operation outputs may not be well specified
+        until inputs are bound.
+
+    operation instance
+    operation reference
+    operation handle
+    element
+    node
+        A node in a work graph. Previously described as *WorkElement*.
+
+    operation factory
+    operation helper
+        The syntax of UI-level functions that instantiate operations is specified by
+        the API, but can extend the syntax implied by the serialized representation
+        of a node for flexibility and user-friendliness.
+
+    port
+        Generic term for a named source, sink, resource, or binding hook on a node.
+
+    resource
+        Describes an API hook for an interaction mediated by a Context. Data flow
+        is described as *immutable* resources (generally produced as Operation outputs)
+        that can be consumed by binding to Operation inputs or by extracting as *results*
+        from the API. Some interactions cannot be represented in terms of producers
+        and subscribers of immutable data events: *Mutable* resources cannot be
+        managed by the Context as data events and require different work scheduling
+        policies that either (a) allows arbitrary (unscheduled) call-back through the API framework,
+        (b) dispatch the mutable resource collaboration to another Context, or (c)
+        allow operations to bind and interact with an interface not specified by the
+        API or not known to the responsible Context implementation. Examples include
+        the Context-provided *ensemble_reduce* functionality, the ensemble simulation
+        signaling facility (by which extension code can terminate a simulation early),
+        and the binding mechanism by which MD extension code can be attached to an
+        *MD* operation as a plugin. The nature of a resource is indicated by the
+        namespace of its *port* in the work record.
+
+.. glossary::
+
+    discovered task
+        A task that has become runnable, but was not already scheduled.
+        This term is intentionally vague as the requirements and constraints of
+        work management are explored. The primary usage refers to a task that
+        has been generated due to adaptations in the work flow. It may also
+        apply to tasks that may be scheduled opportunistically, or simply to
+        the change of state when a task's input dependencies have been met.
+
+    simulation segment
+    trajectory segment
+        A sequence of molecular simulation iterations or frames produced
+        deterministically (within numerical limits) under well-determined
+        parameters. For the purposes of discussing checkpoint intervals or the
+        minimum amount of work executed between API calls, it is useful to
+        distinguish between full simulation trajectories and the irreducible
+        unit of work supported by a simulation library. In the simplest API use
+        cases, a simulation library does not interact with the API during
+        production of a simulation segment, and allows for reinitialization
+        between simulation segments. This allows for unambiguous labeling of the
+        artifacts of a segment. Optimizations may focus on reducing overhead
+        between successive simulation segments (minimizing reinitialization).
+        Extensions may introduce abstractions for well-characterized non-constant
+        parameters, such as time-varying lambda values, though such abstractions
+        are not required in the API since the effect can be achieved through
+        binding to a mutable resource (with details beyond the scope of the API)
+        owned by another operation whose state and action is well characterized
+        for the segment.
+
+
+.. glossary::
+
+    edge
+        A graph edge represents a (data) dependency between operations.
+
+    ensemble
+        An ensemble (as used here) is a concept for grouping related work.
+        Defining an ensemble can allow high level work to be defined more
+        conveniently while allowing more efficient management of task and data
+        placement.
+        Ensemble operations (such as scatter, gather, broadcast, and
+        reduce), may be optimized within a single ensemble execution session.
+
+        The run time characteristics of an ensemble include the supported data
+        flow topology and the computing resources to allocate for ensemble
+        workers. When an ensemble scope is entered, the framework may collect
+        or launch new workers to support the ensemble work. Workers may continue
+        to receive additional tasks and data until the ensemble scope changes.
+        The scope of the ensemble session is thus also constrained by the
+        appropriateness of the allocated ensemble worker pool for the available
+        work.
+
+    framework
+        SCALE-MS is a set of specifications, support packages, and software
+        collaborations that provide a framework in which software tools are
+        executed. The term "framework" is used to refer abstractly to the
+        SCALE-MS software stack and to the facilities it coordinates,
+        particularly in documentation contexts where it is appropriate to avoid
+        details of software packaging or implementation.
+
+    graph
+        Work is described as a directed acyclic graph (DAG) of data flow (edges)
+        and operations on the data (nodes).
+
+    node
+        Data sources and specific instances of operations are represented as
+        nodes in a work graph.
+
+        Identity: A node is the uniquely identifiable representation of an
+        operation instance, defined in terms of the inputs and
+        the work they will perform.
+
+        Corollary: the definition of a node is immutable once added to the graph.
+
+        Finer points:
+
+        * The outputs of a node may be accessed and subscribed to at any time.
+        * Internally, nodes may be stateful. They have metadata associated with
+          their degree of completion and, potentially, with references to other
+          nodes to describe intermediate or final results.
+
+    run time
+        .. todo:: Define the scope to be conveyed by the noun "run time".
+
+    worker
+        A process (or group of processes) managed by the framework and able to
+        execute SCALE-MS work as directed by an :doc:`executor <executor>`.
+
+        Workers are configured and launched through the `CPI`. Data and requests
+        for data are provided to the worker by its client. The worker is able
+        to publish both final results and intermediate results for the work it
+        is executing. More generally, the worker publishes updates to the work
+        graph, which include state updates for existing graph nodes as well as
+        new nodes. New nodes are necessary to hold static data, to describe
+        operations dispatched in support of higher level operations, or to
+        extend the work graph (such as in support of adaptive work flows).
+
+        A worker may be launched to perform a single task, to perform a sequence
+        of tasks, or to participate in an :term:`ensemble`.
+
+
+.. _user classification:
+
+User classes and characteristics
+--------------------------------
+
+Users are assumed to be molecular science researchers using Python scripts to
+express and execute simulation and analysis work consisting of multiple
+simulation and analysis tasks, using software tools from multiple packages.
+
+Software tools are individually accessible as Python modules or as command line
+tools.
+
+Computational work may require multiple invocations (multiple HPC jobs) to complete.
+
+The following classes of user are not necessarily mutually exclusive.
+
+.. glossary::
+
+    basic user
+        A researcher writing a Python script to control standard software.
+
+    advanced user
+        A researcher who needs to integrate custom code into the scripted work.
+
+    pure Python user
+        All software necessary for the work is importable as Python modules.
+
+    mixed command line user
+        Some software is only accessible to Python by wrapping a command line driven tool.
+
+    compiled extension user
+        Some software necessary for the work requires compilation and/or installation
+        on the computing resource.
+
+    direct user
+    local user
+        Work is executed directly in the process(es) launched by the user.
+        Examples include a Python interpreter launched on the user's desktop or
+        a script launched with :command:`mpiexec` in a terminal window.
+
+    indirect user
+    remote user
+        A script run by the user dispatches serialized work through API-enabled
+        middleware for deserialization and execution outside of the user's
+        Python interpreter. In addition to remote execution systems, this class
+        may include adapters to *container* systems or job queuing systems,
+        whether or not the execution occurs on the same machine as the initial
+        Python interpreter.
+
+It is useful to define some classes of client code.
+These roles are relevant in describing use cases,
+or as the subjects of user stories.
+
+.. glossary::
+
+    iterative method
+        Similar work is performed repeatedly. The method may greatly constrain
+        the complexity of the data flow topology compared to an equal number of
+        unrelated tasks. The sequence of tasks may be arbitrarily long or short,
+        and may not be knowable when the work begins execution. Examples include
+        *while* loops and *for* loops.
+
+    adaptive method
+        Work is modified in response to task results. Modifications generally
+        amount to extending the :term:`work graph` but we should consider how
+        best to express cases in which previously expressed work becomes
+        unnecessary. An :term:`iterative method` may be considered a sub-class
+        of *adaptive method* when the stop condition requires evaluation of
+        other task output.
+
+    ensemble method
+        Typified by parallel edges in a :term:`work graph` or subgraphs
+        containing multiple high level single-instruction-multiple-data sorts of
+        operations. As a usage class, we are considering cases where :term:`tasks <task>`
+        are not tightly coupled, though :term:`operations <operation>`
+        may be loosely coupled, or otherwise asynchronous
+        :term:`instances <operation instance>`
+        may be interspersed with coupled / synchronous operations.
+        An *ensemble method* includes work and data that may be decomposed for
+        asynchronous execution. Notably, the same decomposition is highly likely to
+        be applicable to later work.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -2,11 +2,132 @@
 Terms and concepts
 ==================
 
-Concepts and terminology may overlap with existing technologies,
-whereas the requirements specified here are intended to be agnostic to specific solutions.
-This document assumes the following definitions of potentially overloaded key words.
+High level terms and concepts
+=============================
+
+This glossary section describes terms and concepts relevant to the SCALE-MS
+high level API and applications developed against it.
+
+.. Terms appearing in user documentation should be defined here. Before introducing
+   a potentially confusing term here, consider whether it should be restricted to
+   lower level or developer/design documentation. Consider avoiding such terms in
+   user level documentation, or providing an annotation of its technical nature
+   when providing a link to the lower-level details.
+
+Components
+----------
+
+A SCALE-MS based tool kit involves multiple software components.
+The SCALE-MS packages comprise several components that are usually not visible
+to basic research users. This section describes distinct components and concepts
+that may be referenced in SCALE-MS documentation.
+Component visibility and relevance should be annotated.
 
 .. glossary::
+    :sorted:
+
+    API
+    data flow scripting interface
+        Application programming interface. This is the software interface on
+        which SCALE-MS based applications or scripts are written.
+
+    CPI
+        *TDB*
+        The interface used within the framework to launch workers and place tasks.
+
+    application
+        Software written in terms of the SCALE-MS :term:`API`. May be limited
+        to :term:`client` code, or may include extension software that uses the
+        SCALE-MS :term:`API` and :term:`framework` to compose work for managed
+        execution.
+
+    client
+    API client
+        Software or human user of the :term:`API`.
+
+    client package
+        A software package that implements the SCALE-MS :term:`API`.
+
+    executor
+        *TBD*
+        A :term:`CPI` client.
+
+    execution manager
+        *TBD*
+        A :term:`middleware` component that determines :term:`task` placement.
+
+    framework
+        SCALE-MS is a set of specifications, support packages, and software
+        collaborations that provide a framework in which software tools are
+        executed. The term *framework* is used in this documentation to refer
+        abstractly to the SCALE-MS software stack and to the facilities it coordinates,
+        particularly in documentation contexts where it is appropriate to avoid
+        details of software packaging or implementation. When multiple software
+        frameworks are interacting, we should be more specific, but we may neglect
+        to specify *SCALE-MS framework* when the context seems unambiguous.
+
+    middleware
+        The :term:`client package` dispatches :term:`work` for execution through
+        a layer of abstraction that is logically separated from the :term:`run time`
+        layer to allow flexible connection to very different computing resources,
+        scheduling, and work management systems.
+
+    run time
+        The software environment in which SCALE-MS :term:`task` s are executed.
+
+    script
+        Instructions issued to a Python interpreter session that includes import
+        of the :term:`client package`. Note that, even if no :term:`API` instructions
+        are issued, SCALE-MS software may be initialized during module import.
+        The *script* is used to mean the scope of the :term:`client package`
+        module activity.
+
+    simulator
+        Software called by SCALE-MS that can be instructed to carry out
+        molecular simulation work.
+        The simulator may be a separate executable (accessed through the command line),
+        or a library (accessed through a Python, C++, or gRPC API).
+        The SCALE-MS API abstracts these calls so that the user does not need to
+        know how the simulator is being accessed.
+
+    worker
+        The unit of allocation of runtime computing resources:
+        A process (or group of processes, such as spanning the ranks of an MPI context),
+        managed by a run time system through the framework and able to
+        execute SCALE-MS :term:`work` as directed by an :doc:`executor <executor>`.
+
+        Should not be relevant to the user,
+        but may figure into the implementation details of task dispatching.
+
+        Workers are configured and launched through the :term:`CPI`.
+        Data and requests for data are provided to the worker by its CPI client.
+        The worker is able to publish both final results and intermediate
+        results for the work it is executing.
+        More generally, the worker publishes updates to the work graph,
+        which include state updates for existing graph nodes as well as
+        new nodes.
+        New nodes are necessary to hold static data,
+        to describe operations dispatched in support of higher level operations,
+        or to extend the work graph (such as in support of adaptive work flows).
+
+        A worker may be launched to perform a single task, to perform a sequence
+        of tasks, or to participate in an :term:`ensemble`.
+
+    work flow
+        *TBD*
+
+    work load
+        A representation of work that is dispatched for managed execution,
+        represented in SCALE-MS in terms of a :term:`graph` or portion thereof.
+        May be dynamic, with additional work added after dispatch.
+
+.. todo:: Separate essential user-level definition from more in-depth discussion.
+
+Interface terminology
+---------------------
+
+.. glossary::
+    :sorted:
 
     command
         Places one or more operations into the work graph.
@@ -15,8 +136,48 @@ This document assumes the following definitions of potentially overloaded key wo
         of a node for flexibility and user-friendliness. May be a *factory* for
         an operation implementation.
 
+    function
+    operation implementation
+        A well defined computational element or data transformation that can be used
+        to add computational :term:`work` to a :term:`graph`. The SCALE-MS
+        :term:`client package` includes various built-in functions with which to
+        connect external functions (imported from SCALE-MS compatible software
+        packages) or custom user-provided code.
+
+        The function implementation strongly specifies allowed inputs,
+        and behavior for a given set of inputs is deterministic
+        (within numerical stability). Outputs may not be well specified
+        until inputs are bound
+        (*e.g.* until an :term:`instance <operation instance>` is created).
+
+    operation
+    operation instance
+        Data sources and specific instances of :term:`function` s.
+
+        *Operations* can be thought of as nodes in a :term:`work graph`.
+        .. Previously described as *WorkElement* or *node*.
+
+        Identity: An *operation* is the uniquely identifiable representation of a
+        :term:`function` instance, defined in terms of the inputs and
+        specified behavior.
+
+        Corollary: the definition of an operation (a node) is immutable once added to the graph.
+
+        Finer points:
+
+        * The outputs of an operation may be accessed and subscribed to at any time.
+        * Internally, operations may be stateful. They have metadata associated with
+          their degree of completion and, potentially, with references to other
+          resources to describe intermediate or final results.
+
+Data flow terminology
+---------------------
+
+.. glossary::
+    :sorted:
+
     edge
-        A graph edge represents a (data) dependency between operations.
+        A graph edge represents a (data) dependency between :term:`operation` s.
 
     ensemble
         An ensemble (as used here) is a concept for grouping related work.
@@ -35,21 +196,29 @@ This document assumes the following definitions of potentially overloaded key wo
         appropriateness of the allocated ensemble worker pool for the available
         work.
 
-    framework
-        SCALE-MS is a set of specifications, support packages, and software
-        collaborations that provide a framework in which software tools are
-        executed. The term "framework" is used to refer abstractly to the
-        SCALE-MS software stack and to the facilities it coordinates,
-        particularly in documentation contexts where it is appropriate to avoid
-        details of software packaging or implementation.
+    port
+        Generic term for a named source, sink, resource, or binding hook on a node.
+        :term:`operation` s provide and consume resources through named *ports*.
 
-    function
-    operation implementation
-        A well defined computational element or data transformation that can be used
-        to add computational work to a graph managed by a Context. Inputs
-        are strongly specified, and behavior for a given set of inputs is deterministic
-        (within numerical stability). Outputs may not be well specified
-        until inputs are bound (*e.g.* until an instance is created).
+    work
+    graph
+    work graph
+        A prescription to produce computational results, packaged for dispatching and execution.
+
+        Work is described as a directed acyclic graph (DAG) of data flow (:term:`edge` s)
+        and operations on the data (:term:`operation` s).
+        Work represents the computational products
+        requested by a client, but may be an abstraction for lower level tasks,
+        and the exact work load may not be determined until run time.
+
+Development and implementation
+==============================
+
+Concepts and terminology may overlap with existing technologies,
+whereas the requirements specified here are intended to be agnostic to specific solutions.
+This document assumes the following definitions of potentially overloaded key words.
+
+.. glossary::
 
     graph state
         The aggregation of state for operations (nodes) and data (edges),
@@ -58,35 +227,19 @@ This document assumes the following definitions of potentially overloaded key wo
         state must account for completed and incomplete operations, and allow
         distinction between idle and currently executing nodes.
 
-    operation
-    operation instance
-        A node in a work graph. Previously described as *WorkElement* or *node*.
-
-        Data sources and specific instances of operations are represented as
-        nodes in a work graph.
-
-        Identity: A node is the uniquely identifiable representation of a
-        :term:`function` instance, defined in terms of the inputs and
-        specified behavior.
-
-        Corollary: the definition of an operation (a node) is immutable once added to the graph.
-
-        Finer points:
-
-        * The outputs of an operation may be accessed and subscribed to at any time.
-        * Internally, operations may be stateful. They have metadata associated with
-          their degree of completion and, potentially, with references to other
-          resources to describe intermediate or final results.
-
-    port
-        Generic term for a named source, sink, resource, or binding hook on a node.
+    computing resource
+        Facility, resource, capability, or detail of a computing environment
+        that must be allocated and accessed to dispatch and execute computational
+        tasks. Not to be confused with :term:`API resource`.
 
     resource
+    API resource
         Describes an API hook for an interaction mediated by a Context. Data flow
-        is described as *immutable* resources (generally produced as Operation outputs)
-        that can be consumed by binding to Operation inputs or by extracting as *results*
-        from the API. Some interactions cannot be represented in terms of producers
-        and subscribers of immutable data events: *Mutable* resources cannot be
+        is described as *immutable* resources (generally produced as :term:`operation` outputs)
+        that can be consumed by binding to :term:`function` inputs (subscribing)
+        or by extracting as *results* from the API.
+        Some interactions cannot be represented in terms of producers
+        and subscribers of immutable data events: *mutable* resources cannot be
         managed by the Context as data events and require different work scheduling
         policies that either (a) allows arbitrary (unscheduled) call-back through the API framework,
         (b) dispatch the mutable resource collaboration to another Context, or (c)
@@ -98,11 +251,18 @@ This document assumes the following definitions of potentially overloaded key wo
         *MD* operation as a plugin. The nature of a resource is indicated by the
         namespace of its *port* in the work record.
 
-    run time
-        .. todo:: Define the scope to be conveyed by the noun "run time".
+        Not to be confused with :term:`computing resource`
 
     simulation segment
+        The smallest amount of :term:`simulator` :term:`work` that is representable
+        within SCALE-MS. May correspond to a single API call, a check-point
+        interval, a call-back interval, a trajectory output interval, or whatever
+        unit of abstract simulation work is necessary to discuss the unit of
+        identifiable and reproducible simulation output: a :term:`trajectory segment`.
+
     trajectory segment
+        The smallest unit of reproducible :term:`simulator` output for a
+        simulation :term:`operation`.
         A sequence of molecular simulation iterations or frames produced
         deterministically (within numerical limits) under well-determined
         parameters. For the purposes of discussing checkpoint intervals or the
@@ -121,55 +281,27 @@ This document assumes the following definitions of potentially overloaded key wo
         owned by another operation whose state and action is well characterized
         for the segment.
 
+        .. Note: If there are sequences of simulation frames that cannot be meaningfully
+            decomposed at the SCALE-MS level, then that is a segment.
+            If several such segments are independently identifiable,
+            but not individually meaningful because they are coupled by some ensemble method,
+            then they are "coupled segments" or an "ensemble segment," I think.
+
     task
-        The smallest divisible unit of work representable within the API.
+        The unit of work at the :term:`CPI` or :term:`run time` level.
         Generally an :term:`operation` or a portion of an operation that has
         been decomposed in terms of decoupled parallelism or execution checkpoint
         interval.
 
-    work
-    graph
-    work graph
-        A task or tasks, packaged for dispatching and execution.
-
-        Work is described as a directed acyclic graph (DAG) of data flow (edges)
-        and operations on the data (nodes).
-        Work represents the computational products
-        requested by a client, but may be an abstraction for lower level tasks,
-        and the exact work load may not be determined until run time.
-
-    worker
-        The unit of allocation of runtime computing resources. Should not be
-        relevant to the user, but may figure into the implementation details of
-        task dispatching.
-
-        A process (or group of processes) managed by the framework and able to
-        execute SCALE-MS work as directed by an :doc:`executor <executor>`.
-
-        Workers are configured and launched through the `CPI`. Data and requests
-        for data are provided to the worker by its client. The worker is able
-        to publish both final results and intermediate results for the work it
-        is executing. More generally, the worker publishes updates to the work
-        graph, which include state updates for existing graph nodes as well as
-        new nodes. New nodes are necessary to hold static data, to describe
-        operations dispatched in support of higher level operations, or to
-        extend the work graph (such as in support of adaptive work flows).
-
-        A worker may be launched to perform a single task, to perform a sequence
-        of tasks, or to participate in an :term:`ensemble`.
-
-    CPI
-        .. todo:: Define CPI.
-
     Context
-      Abstraction for the entity that maps work to a computing environment.
-      Instances may be long-lived and participate in owning/managing work and
-      data references.
+        Abstraction for the software component that maps work to a computing environment.
+        Instances may be long-lived and participate in owning/managing work and
+        data references.
 
     Session
-      Abstraction for the entity representing work that is executing on resources
-      allocated by an instance of a Context implementation. The Session is the
-      scoped active state of a Context while computing resources are held.
+        Object or abstraction representing work that is executing on computing resources
+        allocated by an instance of a Context implementation. The Session is the
+        scoped active state of a Context while computing resources are held.
 
 .. topic:: *Context* and *Session*
 
@@ -181,94 +313,10 @@ This document assumes the following definitions of potentially overloaded key wo
     otherwise be owned directly by the client, and so its lifetime must span all
     references to resources, operation handles, and data futures.
 
-.. glossary::
-
-    discovered task
+..    discovered task
         A task that has become runnable, but was not already scheduled.
         This term is intentionally vague as the requirements and constraints of
         work management are explored. The primary usage refers to a task that
         has been generated due to adaptations in the work flow. It may also
         apply to tasks that may be scheduled opportunistically, or simply to
         the change of state when a task's input dependencies have been met.
-
-.. _user classification:
-
-User classes and characteristics
---------------------------------
-
-Users are assumed to be molecular science researchers using Python scripts to
-express and execute simulation and analysis work consisting of multiple
-simulation and analysis tasks, using software tools from multiple packages.
-
-Software tools are individually accessible as Python modules or as command line
-tools.
-
-Computational work may require multiple invocations (multiple HPC jobs) to complete.
-
-The following classes of user are not necessarily mutually exclusive.
-
-.. glossary::
-
-    basic user
-        A researcher writing a Python script to control standard software.
-
-    advanced user
-        A researcher who needs to integrate custom code into the scripted work.
-
-    pure Python user
-        All software necessary for the work is importable as Python modules.
-
-    mixed command line user
-        Some software is only accessible to Python by wrapping a command line driven tool.
-
-    compiled extension user
-        Some software necessary for the work requires compilation and/or installation
-        on the computing resource.
-
-    direct user
-    local user
-        Work is executed directly in the process(es) launched by the user.
-        Examples include a Python interpreter launched on the user's desktop or
-        a script launched with :command:`mpiexec` in a terminal window.
-
-    indirect user
-    remote user
-        A script run by the user dispatches serialized work through API-enabled
-        middleware for deserialization and execution outside of the user's
-        Python interpreter. In addition to remote execution systems, this class
-        may include adapters to *container* systems or job queuing systems,
-        whether or not the execution occurs on the same machine as the initial
-        Python interpreter.
-
-It is useful to define some classes of client code.
-These roles are relevant in describing use cases,
-or as the subjects of user stories.
-
-.. glossary::
-
-    iterative method
-        Similar work is performed repeatedly. The method may greatly constrain
-        the complexity of the data flow topology compared to an equal number of
-        unrelated tasks. The sequence of tasks may be arbitrarily long or short,
-        and may not be knowable when the work begins execution. Examples include
-        *while* loops and *for* loops.
-
-    adaptive method
-        Work is modified in response to task results. Modifications generally
-        amount to extending the :term:`work graph` but we should consider how
-        best to express cases in which previously expressed work becomes
-        unnecessary. An :term:`iterative method` may be considered a sub-class
-        of *adaptive method* when the stop condition requires evaluation of
-        other task output.
-
-    ensemble method
-        Typified by parallel edges in a :term:`work graph` or subgraphs
-        containing multiple high level single-instruction-multiple-data sorts of
-        operations. As a usage class, we are considering cases where :term:`tasks <task>`
-        are not tightly coupled, though :term:`operations <operation>`
-        may be loosely coupled, or otherwise asynchronous
-        :term:`instances <operation instance>`
-        may be interspersed with coupled / synchronous operations.
-        An *ensemble method* includes work and data that may be decomposed for
-        asynchronous execution. Notably, the same decomposition is highly likely to
-        be applicable to later work.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ for data flow driven molecular simulation management and analysis.
     :maxdepth: 2
 
     developer
+    glossary
 
 ..  samples
     srs
@@ -17,3 +18,4 @@ for data flow driven molecular simulation management and analysis.
     gmxapi
 
 These document drafts are maintained at https://github.com/SCALE-MS/scale-ms/
+and published online at https://scale-ms.readthedocs.io/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,3 +22,86 @@ Execution of dynamic work
 An abstract work graph guides the generation and placement of tasks and input
 data, informed by the availability of operation results that satisfy task data
 dependencies or client requests.
+
+.. _user classification:
+
+User classes and characteristics
+================================
+
+Human users are assumed to be molecular science researchers using Python scripts to
+express and execute simulation and analysis work consisting of multiple
+simulation and analysis tasks, using software tools from multiple packages.
+Non-human users may be :term:`script` s or any software participant interacting
+with a part of the SCALE-MS :term:`framework`. If the term *user* does not seem
+right to you, please consider substituting *role* in the following section.
+
+The following classes of user are not necessarily mutually exclusive.
+
+.. glossary::
+
+    basic user
+        A researcher writing a Python script to control standard software.
+
+    advanced user
+        A researcher who needs to integrate custom code into the scripted work.
+
+    pure Python user
+        All software necessary for the work is importable as Python modules.
+
+    mixed command line user
+        Some software is only accessible to Python by wrapping a command line driven tool.
+
+    compiled extension user
+        Some software necessary for the work requires compilation and/or installation
+        on the computing resource.
+
+    direct user
+    local user
+        Work is executed directly in the process(es) launched by the user.
+        Examples include a Python interpreter launched on the user's desktop or
+        a script launched with :command:`mpiexec` in a terminal window.
+
+    indirect user
+    remote user
+        A script run by the user dispatches serialized work through API-enabled
+        middleware for deserialization and execution outside of the user's
+        Python interpreter. In addition to remote execution systems, this class
+        may include adapters to *container* systems or job queuing systems,
+        whether or not the execution occurs on the same machine as the initial
+        Python interpreter.
+
+.. seealso:: `Discussion <https://github.com/SCALE-MS/scale-ms/pull/27/files#r385761509>`_
+    of a potentially more basic user.
+
+It is useful to define some classes of client code.
+These roles are relevant in describing use cases,
+or as the subjects of user stories.
+
+.. glossary::
+
+    iterative method
+        Similar work is performed repeatedly. The method may greatly constrain
+        the complexity of the data flow topology compared to an equal number of
+        unrelated tasks. The sequence of tasks may be arbitrarily long or short,
+        and may not be knowable when the work begins execution. Examples include
+        *while* loops and *for* loops.
+
+    adaptive method
+        Work is modified in response to task results. Modifications generally
+        amount to extending the :term:`work graph` but we should consider how
+        best to express cases in which previously expressed work becomes
+        unnecessary. An :term:`iterative method` may be considered a sub-class
+        of *adaptive method* when the stop condition requires evaluation of
+        other task output.
+
+    ensemble method
+        Typified by parallel edges in a :term:`work graph` or subgraphs
+        containing multiple high level single-instruction-multiple-data sorts of
+        operations. As a usage class, we are considering cases where :term:`tasks <task>`
+        are not tightly coupled, though :term:`operations <operation>`
+        may be loosely coupled, or otherwise asynchronous
+        :term:`instances <operation instance>`
+        may be interspersed with coupled / synchronous operations.
+        An *ensemble method* includes work and data that may be decomposed for
+        asynchronous execution. Notably, the same decomposition is highly likely to
+        be applicable to later work.


### PR DESCRIPTION
Establish a base line of defined terms to promote
consistent documentation and clear discussion.

The initial commit collects glossaries from other PRs so that we can focus on defining terms as quickly as possible.

Still to do:

- [x] Clean up the lay out / organization.
- [x] Refine definitions based on discussions to date.
- [ ] Achieve consensus on terminology.
