### PR TITLE
Remove `output` DataProxy descriptor.

### DIFF
--- a/examples/asynch_adaptive_msm/async_queue.py
+++ b/examples/asynch_adaptive_msm/async_queue.py
@@ -66,15 +66,15 @@ with analysis_iteration:
     # Get the output trajectories and pass to PyEmma to build the MSM
     # Return a stop condition object that can be used in gmx while loop to
     # terminate the simulation
-    allframes = collect_coordinates(md.output.trajectory)
+    allframes = collect_coordinates(md.trajectory)
 
     adaptive_msm = msmtool.msm_analyzer(topfile=initial_pdb,
                                         trajectory=allframes,
                                         transition_matrix=analysis_iteration.transition_matrix)
 
     # Update the persistent data for the subgraph
-    analysis_iteration.transition_matrix = adaptive_msm.output.transition_matrix
-    analysis_iteration.is_converged = adaptive_msm.output.is_converged
+    analysis_iteration.transition_matrix = adaptive_msm.transition_matrix
+    analysis_iteration.is_converged = adaptive_msm.is_converged
 
     # Finish the iteration with conditional logic (1) to avoid adding more
     # unnecessary simulations to the queue, and (2) to allow this subgraph to
@@ -82,7 +82,7 @@ with analysis_iteration:
     with scalems.conditional(condition=scalems.logical_not(analysis_iteration.is_converged)):
         # Use the MSM update to generate simulation inputs for further refinement.
         modified_input = modify_input(
-            input=initial_simulation_input, structure=adaptive_msm.output.conformation)
+            input=initial_simulation_input, structure=adaptive_msm.conformation)
         scalems.map(queue.put, simulate(modified_input))
 
 # In the default work graph, add a node that depends on `condition` and

--- a/examples/asynch_adaptive_msm/unordered_mapping.py
+++ b/examples/asynch_adaptive_msm/unordered_mapping.py
@@ -21,7 +21,7 @@ initial_input = [initial_simulation_input] * num_simulations
 
 
 # Get the Future for the sequenced iterable of MD trajectories.
-trajectory_sequence = simulate(input=initial_input).output.trajectory
+trajectory_sequence = simulate(input=initial_input).trajectory
 
 # Convert the sequence Future to an unordered iterable Future.
 trajectory_unordered_collection = scalems.desequence(trajectory_sequence)

--- a/examples/parallel_adaptive_msm/workflow.py
+++ b/examples/parallel_adaptive_msm/workflow.py
@@ -62,16 +62,16 @@ with simulation_and_analysis_iteration:
     # Get the output trajectories and pass to PyEmma to build the MSM
     # Return a stop condition object that can be used in gmx while loop to
     # terminate the simulation
-    allframes = collect_coordinates(md.output.trajectory)
+    allframes = collect_coordinates(md.trajectory)
 
     adaptive_msm = msmtool.msm_analyzer(topfile=initial_pdb,
                                         trajectory=allframes,
                                         transition_matrix=simulation_and_analysis_iteration.transition_matrix)
     # Update the persistent data for the subgraph
-    simulation_and_analysis_iteration.transition_matrix = adaptive_msm.output.transition_matrix
+    simulation_and_analysis_iteration.transition_matrix = adaptive_msm.transition_matrix
     # adaptive_msm here is responsible for maintaining the ensemble width
-    simulation_and_analysis_iteration.conformation = adaptive_msm.output.conformation
-    simulation_and_analysis_iteration.is_converged = adaptive_msm.output.is_converged
+    simulation_and_analysis_iteration.conformation = adaptive_msm.conformation
+    simulation_and_analysis_iteration.is_converged = adaptive_msm.is_converged
 
 # In the default work graph, add a node that depends on `condition` and
 # wraps subgraph.


### PR DESCRIPTION
Example scripts (inconsistently) represent the gmxapi
`output` data descriptor that produced the DataProxy handle
for output collections. Remove according to #48.

Fixes #48 