### PR TITLE
Trajectory data shaping

### DIFF
--- a/examples/asynch_adaptive_msm/async_queue.py
+++ b/examples/asynch_adaptive_msm/async_queue.py
@@ -66,15 +66,15 @@ with analysis_iteration:
     # Get the output trajectories and pass to PyEmma to build the MSM
     # Return a stop condition object that can be used in gmx while loop to
     # terminate the simulation
-    allframes = collect_coordinates(md.output.trajectory)
+    allframes = collect_coordinates(md.trajectory)
 
     adaptive_msm = msmtool.msm_analyzer(topfile=initial_pdb,
                                         trajectory=allframes,
                                         transition_matrix=analysis_iteration.transition_matrix)
 
     # Update the persistent data for the subgraph
-    analysis_iteration.transition_matrix = adaptive_msm.output.transition_matrix
-    analysis_iteration.is_converged = adaptive_msm.output.is_converged
+    analysis_iteration.transition_matrix = adaptive_msm.transition_matrix
+    analysis_iteration.is_converged = adaptive_msm.is_converged
 
     # Finish the iteration with conditional logic (1) to avoid adding more
     # unnecessary simulations to the queue, and (2) to allow this subgraph to
@@ -82,7 +82,7 @@ with analysis_iteration:
     with scalems.conditional(condition=scalems.logical_not(analysis_iteration.is_converged)):
         # Use the MSM update to generate simulation inputs for further refinement.
         modified_input = modify_input(
-            input=initial_simulation_input, structure=adaptive_msm.output.conformation)
+            input=initial_simulation_input, structure=adaptive_msm.conformation)
         scalems.map(queue.put, simulate(modified_input))
 
 # In the default work graph, add a node that depends on `condition` and

--- a/examples/asynch_adaptive_msm/unordered_mapping.py
+++ b/examples/asynch_adaptive_msm/unordered_mapping.py
@@ -21,7 +21,7 @@ initial_input = [initial_simulation_input] * num_simulations
 
 
 # Get the Future for the sequenced iterable of MD trajectories.
-trajectory_sequence = simulate(input=initial_input).output.trajectory
+trajectory_sequence = simulate(input=initial_input).trajectory
 
 # Convert the sequence Future to an unordered iterable Future.
 trajectory_unordered_collection = scalems.desequence(trajectory_sequence)

--- a/examples/parallel_adaptive_msm/workflow.py
+++ b/examples/parallel_adaptive_msm/workflow.py
@@ -15,7 +15,7 @@ import scalems
 from . import msmtool
 
 # Get a set of simulation tools following a common interface convention.
-from scalems.wrappers.gromacs import collect_coordinates, internal_to_pdb, make_input, modify_input, simulate
+from scalems.wrappers.gromacs import get_trajectory, internal_to_pdb, make_input, modify_input, simulate
 
 # Acquire simulation inputs. Generic data hierarchy is not yet clear. Model,
 # method, instance/system/conformation/microstate, and implementation details
@@ -59,11 +59,12 @@ with simulation_and_analysis_iteration:
         input=initial_input, structure=simulation_and_analysis_iteration.conformation)
     md = simulate(input=modified_input)
 
+    # Collect frames from all output trajectories.
+    allframes = scalems.reduce(scalems.extend_sequence, get_trajectory(md))
+
     # Get the output trajectories and pass to PyEmma to build the MSM
     # Return a stop condition object that can be used in gmx while loop to
     # terminate the simulation
-    allframes = collect_coordinates(md.trajectory)
-
     adaptive_msm = msmtool.msm_analyzer(topfile=initial_pdb,
                                         trajectory=allframes,
                                         transition_matrix=simulation_and_analysis_iteration.transition_matrix)

--- a/examples/parallel_adaptive_msm/workflow.py
+++ b/examples/parallel_adaptive_msm/workflow.py
@@ -62,16 +62,16 @@ with simulation_and_analysis_iteration:
     # Get the output trajectories and pass to PyEmma to build the MSM
     # Return a stop condition object that can be used in gmx while loop to
     # terminate the simulation
-    allframes = collect_coordinates(md.output.trajectory)
+    allframes = collect_coordinates(md.trajectory)
 
     adaptive_msm = msmtool.msm_analyzer(topfile=initial_pdb,
                                         trajectory=allframes,
                                         transition_matrix=simulation_and_analysis_iteration.transition_matrix)
     # Update the persistent data for the subgraph
-    simulation_and_analysis_iteration.transition_matrix = adaptive_msm.output.transition_matrix
+    simulation_and_analysis_iteration.transition_matrix = adaptive_msm.transition_matrix
     # adaptive_msm here is responsible for maintaining the ensemble width
-    simulation_and_analysis_iteration.conformation = adaptive_msm.output.conformation
-    simulation_and_analysis_iteration.is_converged = adaptive_msm.output.is_converged
+    simulation_and_analysis_iteration.conformation = adaptive_msm.conformation
+    simulation_and_analysis_iteration.is_converged = adaptive_msm.is_converged
 
 # In the default work graph, add a node that depends on `condition` and
 # wraps subgraph.

--- a/scalems/wrappers/__init__.py
+++ b/scalems/wrappers/__init__.py
@@ -37,12 +37,24 @@ Utility functions:
         converts a native structure object to a structure file in the Protein Data Bank
         (PDB) format.
 
+    get_trajectory(source) -> Trajectory:
+        Get a Future for (currently implementation-specific) Trajectory data from
+        a Simulation or other sensible source. Note: this free function allows us
+        to defer the question of whether trajectory sources are assumed to have a
+        `trajectory` instance attribute.
+
     collect_coordinates(trajectories: scalems.Iterable[scalems.Iterable[Conformation]]) -> scalems.Iterable[Conformation]:
         Some data hierarchies or topological transformations need to be performed
         by native tools. *collect_coordinates* creates a single iterable of
         system conformations from a collection of sources of conformation data.
 
 Module types:
+    Frame:
+        Molecular system microstate data. Generally, a frame of simulation trajectory
+        output, an input configuration, or a subset of simulation snapshot/checkpoint data.
+        At a minimum, the member data is assumed to include atomic coordinates,
+        indexed consistently with other Frames extracted from the same source.
+
     SimulationInput:
         Packages simulation inputs for consumption by other tools in the simulation
         package. If array-like or set-like input is provided, the SimulationInput
@@ -56,5 +68,14 @@ Module types:
         is convertible to SimulationInput. The Simulation reference produced by
         a *simulate()* command has the data flow shape of the SimulationInput
         provided to it.
+
+    Trajectory:
+        A data Future representing molecular system trajectory data. For MD, this
+        is presumed to be a trajectory output file or set of sequenced files.
+        For a Simulation reference encompassing an ensemble or batch of simulations,
+        outer dimensions of the Trajectory reference will describe the same shape
+        as the source. A Trajectory has SCALE-MS sequence semantics. The wrapper
+        should allow sequence-based data shaping commands to treat a Trajectory
+        as a sequence of Frame data.
 
 """


### PR DESCRIPTION
Initial proposal for eliminating the confusing and overspecified `collect_coordinates` simulator wrapper interface.

Replaced by other abstractions and data shaping commands previously described.

Also requires additional implementation work (no longer trivially represented with gmxapi wrappers), deferred until further discussion on concept.