### PR TITLE
Hierarchy of and roadmap for context management syntax.

### DIFF
--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -4,3 +4,90 @@ Execution middleware
 
 Executable graphs or graph segments produced by client software are dispatched
 and translated for execution on managed computing resources.
+
+WorkflowContext
+===============
+
+Information and resources supporting a defined workflow are managed in a scope
+we call a WorkflowContext.
+All ScaleMS API calls and references occur in or between the scopes of WorkflowContext instances.
+When the ScaleMS API is active, there is a notion of a "current" WorkflowContext.
+
+When the scalems module is simply imported, the default context is able to
+discover local workflow state from the working directory and manage a workflow
+representation, but it is not able to dispatch the work directly for execution.
+
+Execution dispatching implementations can be chosen from the command line when
+the interpreter is launched with Python's ``-m`` command line option.
+
+Alternatively, the script can use a Python Context Manager (a ``with`` block) to
+activate a WorkflowContext with an execution dispatcher implementation.
+
+It is inadvisable to activate and execution dispatching environment with
+procedural calls because it is more difficult to make sure that acquired resources
+are properly released if the interpreter has to terminate prematurely.
+
+Execution dispatching contexts
+==============================
+
+Execution dispatching generally uses some sort of concurrency model,
+but there is not a consistent concurrency model for all dispatchers.
+ScaleMS provides abstractions to insulate scripting from particular implementations
+or concurrency primitives (such as the need to call `asyncio.run()`).
+
+Design notes
+------------
+
+Callable and arguments
+~~~~~~~~~~~~~~~~~~~~~~
+
+Arguments will be supplied to the callable when the task is launched.
+Launching a task requires a callable, arguments for the callable, an active
+executor.
+For a concurrent.futures.Executor, the callable and arguments are passed to
+Executor.submit() to get a Task (Future interface).
+For asyncio, it is possible to hold a coroutine object that is not yet executing
+(awaitable, but no Future interface), and then pass it to asyncio.create_task to get a Task (Future interface).
+Alternatively, callable and args can be passed with an executor to asyncio.Loop.run_in_executor()
+to get a asyncio.Future.
+In RP, A ComputeUnit can be created without immediate scheduling, then a Task is
+acquired by "submit"ing.
+The Callable and Arguments distinction, then, is not general. It seems reasonable
+to have an encapsulated task factory that can operate in conjunction with an
+active execution facility to produce a Future. The details of task description ->
+task submission / Future handle -> awaiting on the future can be absorbed into the
+NodeBuilder and proxy Future protocols, but we probably need two states in the
+command handle to indicate whether a Task has been created yet, and a third state
+to indicate its completion (note Future.done() is commonly available.).
+
+Upshot:
+
+1. Handles returned by command helpers may not (yet) be bound to real tasks.
+2. Context implementations need to support an add_task protocol that proxies the
+   details of converting a task description into a Task instance.
+3. A Context<->Context protocol needs to manage Futures that proxy to tasks in
+   other Contexts. Only the simple and unified ScaleMS.Future should be exposed
+   to ordinary users.
+4. We can require Session.run() to be used in the near term to force completion of
+   the task protocol, and absorb that behavior into scalems.wait() and scalems.run()
+   in the long term.
+
+    def canonical_syntax():
+        context = sms_context.get_context()
+        # For testing purposes, we will explicitly create each of the implemented Contexts.
+        # Simple use case:
+        # Use context manager protocol to initialize and finalize connections and resources.
+        with context as session:
+            cmd = executable(('/bin/echo', 'hello', 'world'), stdout='filename')
+            session.run(cmd) # Near-term solution to resolve all awaitables explicitly.
+            # Alternative not yet implemented:
+            #    scalems.wait(cmd.exitcode) # Minimally resolve cmd.exitcode
+            assert cmd.exitcode.done()
+            # In user-facing Contexts, we can make sure that Future.result() does not require explicit waiting.
+            assert cmd.exitcode.result() == 0
+            # No `wait cmd` is necessary because the awaitable will be managed by session clean-up, if necessary.
+        # Higher-level use cases:
+        # * Pass the target context to the command factory to get a command object that is
+        #   already bound to a particular execution framework.
+        # * Set the Context and then call scalems.run(workflow) to get behavior like
+        #   asyncio.run().

--- a/scalems/context/__init__.py
+++ b/scalems/context/__init__.py
@@ -1,0 +1,37 @@
+"""Manage the SCALE-MS Workflow Context.
+
+SCALE-MS optimizes data flow and data locality in part by attributing all
+workflow references to well-defined scopes. Stateful API facilities, workflow
+state, and scoped references are managed as WorkflowContext instances.
+
+This module allows the Python interpreter to track a global stack or tree
+structure to allow for simpler syntax and clean resource de-allocation.
+"""
+
+
+def run(coroutine, **kwargs):
+    """Execute the provided coroutine object.
+
+    Abstraction for :py:func:`asyncio.run()`
+
+    Note: If we want to go this route, we should integrate with the
+    asyncio event loop policy, or obtain an event loop instance and
+    use it w.r.t. run_in_executor and set_task_factory.
+
+    .. todo:: Coordinate with RP plans for event loop contexts and concurrency module executors.
+
+    See also https://docs.python.org/3/library/asyncio-dev.html#debug-mode
+    """
+    # No automatic dispatching yet. Coroutine must be executable
+    # in the current context.
+    import asyncio
+    from asyncio.coroutines import iscoroutine
+
+    # TODO: Check whether coroutine is already executing and where.
+    if iscoroutine(coroutine):
+        return asyncio.run(coroutine, **kwargs)
+
+    # TODO: Consider generalized coroutines to be dispatched through
+    #     custom event loops or executors.
+
+    raise ValueError('Unrecognized awaitable: {}'.format(coroutine))

--- a/scalems/local/__init__.py
+++ b/scalems/local/__init__.py
@@ -1,0 +1,7 @@
+"""Entry point subpackage for local ScaleMS execution.
+
+Example:
+    python3 -m scalems.local my_workflow.py
+
+"""
+# TODO: Consider converting to a namespace package to improve modularity of implementation.

--- a/scalems/local/__main__.py
+++ b/scalems/local/__main__.py
@@ -1,0 +1,23 @@
+"""Local execution dispatching for ScaleMS workflows.
+
+Usage:
+    python3 -m scalems.local my_workflow.py
+
+"""
+
+import runpy
+import sys
+
+# We can import scalems.context and set module state before using runpy to
+# execute the script in the current process. This allows us to preconfigure a
+# default execution manager.
+
+# TODO: Consider whether we want launched scripts to have `__name__` set to `__main__` or not.
+
+# TODO: Consider whether we want to parse execution module arguments, including handling chained `-m`.
+#     Consider generalizing this boilerplate.
+
+# Strip the current __main__ file from argv
+sys.argv[:] = sys.argv[1:]
+# Execute the script.
+runpy.run_path(sys.argv[0])

--- a/scalems/radical/__init__.py
+++ b/scalems/radical/__init__.py
@@ -1,0 +1,7 @@
+"""Entry point subpackage for ScaleMS execution dispatching to RADICAL Pilot.
+
+Example:
+    python -m scalems.radical myworkflow.py
+
+"""
+# TODO: Consider converting to a namespace package to improve modularity of implementation.

--- a/scalems/radical/__main__.py
+++ b/scalems/radical/__main__.py
@@ -1,0 +1,6 @@
+"""Local execution dispatching for ScaleMS workflows.
+
+Usage:
+    python3 -m scalems.radical my_workflow.py
+
+"""

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 setup(
     name='scalems',
     version='0',
+    python_requires='>=3.7',
     packages=['scalems'],
     url='https://github.com/SCALE-MS/scale-ms/',
     license='',


### PR DESCRIPTION
Clarify the scoping of

* workflow management and 
* execution dispatching details.

Proposals:

* Define scalems.wait()
* Define scalems.run()
* Hide asyncio.run() in scalems.run()

Refs #53

Relates somewhat to #14 facets of Operation code