### PR TITLE
Begin managing task directories.

### DIFF
--- a/src/scalems/local/__main__.py
+++ b/src/scalems/local/__main__.py
@@ -45,6 +45,7 @@ exitcode = 0
 try:
     with scalems.context.scope(scalems.local.AsyncWorkflowManager()) as context:
         try:
+            # Check accessibility!
             globals_namespace = runpy.run_path(sys.argv[0])
             # TODO: Use a decorator to annotate which function(s) to run?
             main = None
@@ -60,8 +61,7 @@ try:
         except SystemExit as e:
             exitcode = e.code
 except Exception as e:
-    print('Exception')
-    print(repr(e))
+    print('Exception: {}'.format(repr(e)))
     if exitcode == 0:
         exitcode = 1
 raise SystemExit(exitcode)


### PR DESCRIPTION
This is the beginning of working directory management for tasks.

Each workflow item gets its own working directory.

Ultimately, the working directory will have a universally unique name according to a fingerprint of the product it is expected to produce. For the moment, this identifier is just drawn from a sequence of integers as the work is defined.

I am not merging directly because this change introduces a challenge in locating files produced by other tasks. Workarounds are straightforward, but if they are more trouble than this change is worth for the moment, I can hold off on merging this change until the machinery is in place to easily access task file output by reference.

Also note that this change reveals an important technical detail: the only robust way to make sure a task respects a working directory is to set the current working directory at the scope of a process. Depending on how rigorously we want to sandbox Python-based tasks, we should not yield from a thread during the scope of task execution. We may need to consider more of a process pool than we have previously considered, but we can probably also just assert that task implementation code should not use direct filesystem access (use scalems helpers instead). We can even monkey-patch the built-in modules to preempt negligence, if we find it necessary. I think RP already does this to some extent (logging module?).