### PR TITLE
Try to minimize Python package (re)installations.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,9 +55,9 @@ jobs:
       run: |
         python -m venv testenv
         . testenv/bin/activate
-        python -m pip install --upgrade pip setuptools
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements-testing.txt
-        python -m pip install --upgrade .
+        python -m pip install .
         python -m pip install pytest-cov
     - name: Test with pytest
       env:

--- a/docker/rp-complete.dockerfile
+++ b/docker/rp-complete.dockerfile
@@ -82,32 +82,16 @@ RUN rp-venv/bin/pip install --upgrade \
         python-hostlist \
         setproctitle
 
-RUN . ~rp/rp-venv/bin/activate && \
-    pip install --no-cache-dir --upgrade \
-        'radical.saga>=1.5.2' \
-        'radical.utils>=1.5.2'
-
 # Get repository for example and test files and to simplify RPREF build argument.
 # Note that GitHub may have a source directory name suffix that does not exactly
 # match the branch or tag name, so we use a glob to try to normalize the name.
-#ARG RPREF="v1.5.7"
+#ARG RPREF="v1.6.5"
 ARG RPREF="project/scalems"
 # Note: radical.pilot does not work properly with an "editable install"
-#RUN (cd ~rp && \
-#    . ~rp/rp-venv/bin/activate && \
-#    git clone -b $RPREF --depth=3 https://github.com/radical-cybertools/radical.pilot.git && \
-#    cd radical.pilot && \
-#    pip install -e . \
-#    )
-# We want the sources for the examples and unit tests.
-#RUN (cd ~rp && \
-#    . ~rp/rp-venv/bin/activate && \
-#    pip install "git+https://github.com/radical-cybertools/radical.pilot.git@${RPREF}#egg=radical.pilot")
-# OR first get sources, then
 RUN git clone -b $RPREF --depth=3 https://github.com/radical-cybertools/radical.pilot.git && \
     . ~rp/rp-venv/bin/activate && \
     cd ~rp/radical.pilot && \
-    pip install .
+    pip install --no-cache-dir --no-build-isolation .
 
 
 # Allow RADICAL Pilot to provide more useful behavior during testing,

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -15,7 +15,5 @@ python-hostlist
 setproctitle
 tox>=2.0
 
-radical.saga>=1.5.2
-radical.utils>=1.5.2
-# Use pip install -r requirements.txt --upgrade to get branch updates.
+# Use `pip install -r requirements-testing.txt --upgrade` to get branch updates.
 git+https://github.com/radical-cybertools/radical.pilot.git@project/scalems#egg=radical.pilot

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,14 +21,12 @@ packages = find:
 package_dir =
     =src
 install_requires =
-    radical.pilot@git+https://github.com/radical-cybertools/radical.pilot.git@project/scalems
+    radical.pilot>=1.6.5
 tests_require =
     build
     pytest>=6.1.2
     pytest-asyncio>=0.14
-    radical.saga>=1.5.2
-    radical.utils>=1.5.2
-    radical.pilot@git+https://github.com/radical-cybertools/radical.pilot.git@project/scalems
+    radical.pilot>=1.6.5
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
`pip install -r requirements-testing.txt` will still get the `projects/scalems` branch.

`pip install --upgrade -r requirements-testing.txt` will re-clone the branch.

`pip install .` (for scalems) will respect the RP version installed from VCS, or fetch a tagged release if not found.

This means that, for the moment, we need to manually maintain the `radical.pilot` package installation when using "raptor" features.