### PR TITLE
Enable test_prepare_venv in CI testing.

### DIFF
--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -144,7 +144,13 @@ def test_prepare_venv(rp_task_manager, sdist):
         'rs': os.path.join(os.path.dirname(ru.__file__), sdist_names['rs']),
         'ru': os.path.join(os.path.dirname(ru.__file__), sdist_names['ru'])
     }
+    for path in sdist_local_paths.values():
+        assert os.path.exists(path)
+
     sandbox_path = urllib.parse.urlparse(pilot.pilot_sandbox).path
+    # Note: temporary check only works on localhost
+    assert os.path.exists(sandbox_path)
+
     sdist_session_paths = {name: os.path.join(sandbox_path, sdist_names[name]) for name in sdist_names.keys()}
 
     logger.debug('Staging ' + ', '.join(sdist_session_paths.values()))
@@ -156,7 +162,10 @@ def test_prepare_venv(rp_task_manager, sdist):
             'target': sdist_session_paths[name],
             'action': rp.TRANSFER
         })
-    pilot.stage_in(input_staging)
+    for directive in input_staging:
+        pilot.stage_in(directive)
+        pilot.stage_in(input_staging)
+    # pilot.stage_in(input_staging)
 
     # Note: temporary check only works on localhost
     for path in sdist_session_paths.values():

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -163,7 +163,7 @@ def test_prepare_venv(rp_task_manager, sdist):
         'scalems_env': {
             'type': 'virtualenv',
             'version': '3.8',
-            'setup': list([sdist_session_paths.values()])}})
+            'setup': list(sdist_session_paths.values())}})
 
     td = rp.TaskDescription({'executable': 'python3',
                              'arguments': ['-c',

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -140,10 +140,11 @@ def test_prepare_venv(rp_task_manager, sdist):
     }
     sdist_local_paths = {
         'scalems': sdist,
-        'rp': os.path.join(os.path.dirname(rp.__file__), sdist_names['rp']),
-        'rs': os.path.join(os.path.dirname(ru.__file__), sdist_names['rs']),
-        'ru': os.path.join(os.path.dirname(ru.__file__), sdist_names['ru'])
+        'rp': rp.sdist_path,
+        'rs': rs.sdist_path,
+        'ru': ru.sdist_path
     }
+    logger.debug('Checking paths: ' + ', '.join(sdist_local_paths.values()))
     for path in sdist_local_paths.values():
         assert os.path.exists(path)
 

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -100,7 +100,6 @@ def test_rp_basic_task_remote(rp_task_manager, pilot_description):
     assert remotename != localname
 
 
-@pytest.mark.skipif(condition=bool(os.getenv('CI')), reason='Skipping slow test in CI environment.')
 def test_prepare_venv(rp_task_manager, sdist):
     """Bootstrap the scalems package in a RP target environment using pilot.prepare_env.
 

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -156,6 +156,11 @@ def test_prepare_venv(rp_task_manager, sdist):
             'target': sdist_session_paths[name],
             'action': rp.TRANSFER
         })
+    pilot.stage_in(input_staging)
+
+    # Note: temporary check only works on localhost
+    for path in sdist_session_paths.values():
+        assert os.path.exists(path)
 
     tmgr = rp_task_manager
 

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -161,14 +161,7 @@ def test_prepare_venv(rp_task_manager, sdist):
             'target': sdist_session_paths[name],
             'action': rp.TRANSFER
         })
-    # for directive in input_staging:
-    #     pilot.stage_in(directive)
-    #     pilot.stage_in(input_staging)
     pilot.stage_in(input_staging)
-
-    # Note: temporary check only works on localhost
-    for path in sdist_session_paths.values():
-        assert os.path.exists(path)
 
     tmgr = rp_task_manager
 

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -149,8 +149,6 @@ def test_prepare_venv(rp_task_manager, sdist):
         assert os.path.exists(path)
 
     sandbox_path = urllib.parse.urlparse(pilot.pilot_sandbox).path
-    # Note: temporary check only works on localhost
-    assert os.path.exists(sandbox_path)
 
     sdist_session_paths = {name: os.path.join(sandbox_path, sdist_names[name]) for name in sdist_names.keys()}
 
@@ -163,10 +161,10 @@ def test_prepare_venv(rp_task_manager, sdist):
             'target': sdist_session_paths[name],
             'action': rp.TRANSFER
         })
-    for directive in input_staging:
-        pilot.stage_in(directive)
-        pilot.stage_in(input_staging)
-    # pilot.stage_in(input_staging)
+    # for directive in input_staging:
+    #     pilot.stage_in(directive)
+    #     pilot.stage_in(input_staging)
+    pilot.stage_in(input_staging)
 
     # Note: temporary check only works on localhost
     for path in sdist_session_paths.values():

--- a/tests/test_subprocess_exec.py
+++ b/tests/test_subprocess_exec.py
@@ -16,20 +16,20 @@ from scalems.exceptions import MissingImplementationError
 from scalems.subprocess import executable
 
 
-@pytest.mark.xfail(reason='There is currently no default executor. See also #53, #55, #82')
-def test_exec_default():
-    # Check for expected behavior of the default context
-    with pytest.raises(MissingImplementationError):
-        # Test default context
-        cmd = executable(('/bin/echo',))
-        context = scalems.context.get_context()
-        # Note: we can choose to let Context.run(...) return a contextmanager that
-        # can be used to create a session (if not already entered) that cleans up
-        # after itself as best it can through a weakref from the context when the
-        # reference count goes to zero, making the `with` block optional, but it
-        # may be better to avoid too much automation or alternative ways to do things.
-        with context as session:
-            session.run(cmd)
+# @pytest.mark.xfail(reason='There is currently no default executor. See also #53, #55, #82')
+# def test_exec_default():
+#     # Check for expected behavior of the default context
+#     with pytest.raises(MissingImplementationError):
+#         # Test default context
+#         cmd = executable(('/bin/echo',))
+#         context = scalems.context.get_context()
+#         # Note: we can choose to let Context.run(...) return a contextmanager that
+#         # can be used to create a session (if not already entered) that cleans up
+#         # after itself as best it can through a weakref from the context when the
+#         # reference count goes to zero, making the `with` block optional, but it
+#         # may be better to avoid too much automation or alternative ways to do things.
+#         with context as session:
+#             session.run(cmd)
 
 
 # This does not currently seem to be on the road map.


### PR DESCRIPTION
This test is much faster now because we reuse more venvs and use packages that are available as local archives.

However, I believe we are not guaranteed to get the same radical.pilot package in the prepared venv. I think we should specify the archive of the client RP package that should be staged already in the session sandbox. Suggestions?