### PR TITLE
Basic CLI argument parser.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   max_report_age: off
+  require_ci_to_pass: false
 
 fixes:
   - "*/site-packages/scalems/::src/scalems/"

--- a/.coveragerc
+++ b/.coveragerc
@@ -23,6 +23,6 @@ exclude_lines =
 ignore_errors = True
 
 omit =
-    */_version.py
+    */scalems/_version.py
     # We don't currently have a way to get coverage results for these installed scripts.
-    */scalems_rp*py
+    */scalems/radical/scalems_rp*py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
     - name: Command line tests
       run: |
         . $HOME/testenv/bin/activate
+        coverage run -m scalems.local --version
+        coverage run -m scalems.local --help
         coverage run -m scalems.local examples/basic/echo.py hi there
         python -c 'if open("0000000000000000000000000000000000000000000000000000000000000000/stdout", "r").readline().rstrip() != "hi there": assert False'
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,21 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements-testing.txt
         python -m pip install .
+        python -m pip install pytest-cov coverage
     - name: Test with pytest
       run: |
         . $HOME/testenv/bin/activate
-        python -X dev -m pytest tests -s --rp-venv $HOME/testenv
+        python -X dev -m pytest --cov=scalems --cov-report=xml tests -s --rp-venv $HOME/testenv
+    - name: Command line tests
+      run: |
+        . $HOME/testenv/bin/activate
+        coverage run -m scalems.local examples/basic/echo.py hi there
+        python -c 'if open("0000000000000000000000000000000000000000000000000000000000000000/stdout", "r").readline().rstrip() != "hi there": assert False'
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+        name: codecov-umbrella
 
   containerized_rp:
 

--- a/src/scalems/__init__.py
+++ b/src/scalems/__init__.py
@@ -45,17 +45,16 @@ __all__ = [
 import logging
 
 from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
-# We do not provide a version module or API.
-# Use :py:mod:`packaging.version <https://packaging.pypa.io/en/latest/version/>`
-# or pkg_resources.get_distribution('gmxapi').version for richer interfaces.
-
 from .context import get_context
 from .subprocess import executable
 from .utility import app
 from .utility import ScriptEntryPoint
 
+__version__ = get_versions()['version']
+del get_versions
+# We do not provide a version module or API.
+# Use :py:mod:`packaging.version <https://packaging.pypa.io/en/latest/version/>`
+# or pkg_resources.get_distribution('gmxapi').version for richer interfaces.
 
 logger = logging.getLogger(__name__)
 logger.debug('Imported {}'.format(__name__))

--- a/src/scalems/__init__.py
+++ b/src/scalems/__init__.py
@@ -39,22 +39,23 @@ __all__ = [
     'get_context',
     # 'run',
     # 'wait',
+    '__version__'
 ]
 
 import logging
 
-# Import the singleton early to avoid ambiguity under multi-threaded conditions.
 from ._version import get_versions
-from .context import get_context
-from .subprocess import executable
-from .utility import app
-from .utility import ScriptEntryPoint
-
 __version__ = get_versions()['version']
 del get_versions
 # We do not provide a version module or API.
 # Use :py:mod:`packaging.version <https://packaging.pypa.io/en/latest/version/>`
 # or pkg_resources.get_distribution('gmxapi').version for richer interfaces.
+
+from .context import get_context
+from .subprocess import executable
+from .utility import app
+from .utility import ScriptEntryPoint
+
 
 logger = logging.getLogger(__name__)
 logger.debug('Imported {}'.format(__name__))


### PR DESCRIPTION
Add CLI argument parser and begin testing scalems.local example.

This is a precursor to CLI handling for essential RP runtime parameters (venv, target resource, etc.)