### PR TITLE
Let pytest default to RADICAL_LOG_LVL=DEBUG

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -3,6 +3,7 @@ coverage
 flake8
 pytest>=6.1.2
 pytest-asyncio>=0.14
+pytest-env
 setuptools
 wheel
 # RADICAL requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ tests_require =
     build
     pytest>=6.1.2
     pytest-asyncio>=0.14
+    pytest-env
     radical.pilot>=1.6.5
 
 [options.entry_points]

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 minversion = 3.0
+env =
+    D:RADICAL_LOG_LVL=DEBUG


### PR DESCRIPTION
Use the `pytest-env` plugin to pass the RADICAL_LOG_LVL to the pytest environment with a default value of DEBUG.