### PR TITLE
Add testing for "ssh" RP schema.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         files: ./coverage1.xml,./coverage2.xml
         name: codecov-local-${{ matrix.python-version }}
 
-  containerized_rp:
+  rp_local:
 
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -68,7 +68,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -119,7 +119,92 @@ jobs:
       with:
         fail_ci_if_error: true
         files: ./coverage1.xml,./coverage2.xml
-        name: codecov-radical-${{ matrix.python-version }}
+        name: codecov-rp-local-${{ matrix.python-version }}
+
+  rp_ssh:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      mongodb:
+        image: mongo
+        env:
+          MONGO_INITDB_ROOT_USERNAME: root
+          MONGO_INITDB_ROOT_PASSWORD: password
+        ports:
+        # will assign a random free host port
+        - 27017/tcp
+
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - name: Prepare ssh
+      # Ref: https://stackoverflow.com/questions/60066477/self-connecting-via-ssh-on-github-actions
+      run: |
+        ssh-keygen -f ~/.ssh/id -t ed25519 -N ''
+        echo -n 'from="127.0.0.1" ' | cat - ~/.ssh/id.pub > ~/.ssh/authorized_keys
+        ssh-keyscan 127.0.0.1 >> ~/.ssh/known_hosts
+        chmod og-rw ~
+        ls -la ~/.ssh
+        # Test:
+        eval "$(ssh-agent -s)"
+        ssh-add ~/.ssh/id
+        ssh 127.0.0.1 env
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Increase file limit
+      run: |
+        sudo sysctl -w fs.file-max=65536
+        ulimit -a
+    - name: Install dependencies
+      timeout-minutes: 10
+      run: |
+        python -m venv $HOME/testenv
+        . $HOME/testenv/bin/activate
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade -r requirements-testing.txt
+        python -m pip install .
+        python -m pip install coverage pymongo pytest-cov
+        mkdir -p $HOME/.radical/pilot/configs/
+        cp ./docker/resource_local.json $HOME/.radical/pilot/configs/
+        python -m pip freeze
+        radical-stack
+    - name: Test with pytest
+      timeout-minutes: 10
+      env:
+        RADICAL_PILOT_DBURL: mongodb://root:password@localhost:${{ job.services.mongodb.ports[27017] }}/admin
+      run: |
+        eval "$(ssh-agent -s)"
+        ssh-add ~/.ssh/id
+        . $HOME/testenv/bin/activate
+        export RADICAL_LOG_LVL=DEBUG
+        python -c "import os; import pymongo; print('Create test entry in DB: ', pymongo.MongoClient(os.getenv('RADICAL_PILOT_DBURL')).test.test.insert_one({'x': 10}).inserted_id)"
+        ulimit -n 65536
+        COVERAGE_FILE=$PWD/.coverage python -X dev -m pytest --cov=scalems --cov-report=xml:coverage1.xml -rA -l --log-cli-level=info tests --rp-venv $HOME/testenv --rp-resource=local.github --rp-access=ssh
+    - name: Command line tests
+      timeout-minutes: 3
+      env:
+        RADICAL_PILOT_DBURL: mongodb://root:password@localhost:${{ job.services.mongodb.ports[27017] }}/admin
+      run: |
+        eval "$(ssh-agent -s)"
+        ssh-add ~/.ssh/id
+        . $HOME/testenv/bin/activate
+        coverage run -m scalems.radical --version
+        coverage run --append -m scalems.radical --help
+        coverage run --append -m scalems.radical --venv=$HOME/testenv --resource=local.github --access=ssh --pilot-option cores=1 --pilot-option gpus=0 examples/basic/echo.py hello world
+        coverage xml -o coverage2.xml
+        python -c 'if open("0000000000000000000000000000000000000000000000000000000000000000/stdout", "r").readline().rstrip() != "hello world": assert False'
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+        files: ./coverage1.xml,./coverage2.xml
+        name: codecov-rp-ssh-${{ matrix.python-version }}
 
   lint:
     runs-on: ubuntu-latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,6 +18,10 @@ Containerized RADICAL Pilot testing can be performed two ways.
 Either the (required) MongoDB server can run in the same container
 as RP, or in a separate service container.
 
+The `scalems/radicalpilot` image includes additional resource definitions
+`local.github`, `local.tunnel`, `docker.login`, and `docker.compute`.
+See the `resource_*.json` files in this directory for details.
+
 ## Monolithic container
 
 `rp-complete.dockerfile` provides a recipe for a complete container

--- a/docker/radicalpilot.dockerfile
+++ b/docker/radicalpilot.dockerfile
@@ -71,7 +71,7 @@ RUN rp-venv/bin/pip install --no-cache-dir --upgrade \
 
 RUN  mkdir -p ~/.radical/pilot/configs
 
-COPY --chown=rp:radical resource_local.json /home/rp/.radical/pilot/configs
+COPY --chown=rp:radical resource_*.json /home/rp/.radical/pilot/configs
 
 WORKDIR /home/rp
 

--- a/docker/resource_docker.json
+++ b/docker/resource_docker.json
@@ -1,42 +1,18 @@
 {
-  "github": {
-    "description": "GitHub Actions workflow with a `testenv` venv preconfigured.",
-    "notes": "To use the ssh schema, make sure that ssh access to localhost is enabled.",
+  "login": {
+    "description": "compute service from the docker/stack.yml.",
+    "notes": "Local schema in the 'login' service container.",
     "schemas": [
-      "local"
-    ],
-    "local": {
-      "job_manager_endpoint": "fork://localhost/",
-      "filesystem_endpoint": "file://localhost/"
-    },
-    "default_remote_workdir": "$HOME",
-    "resource_manager": "FORK",
-    "agent_config": "default",
-    "agent_scheduler": "CONTINUOUS",
-    "agent_spawner": "POPEN",
-    "agent_launch_method": "FORK",
-    "task_launch_method": "FORK",
-    "mpi_launch_method": "MPIEXEC",
-    "rp_version": "installed",
-    "virtenv_mode": "use",
-    "virtenv": "$HOME/testenv",
-    "python_dist": "default",
-    "cores_per_node": 8,
-    "gpus_per_node": 1,
-    "lfs_path_per_node": "/tmp",
-    "lfs_size_per_node": 1024,
-    "memory_per_node": 4096,
-    "fake_resources": true
-  },
-  "tunnel": {
-    "description": "Use a local ssh tunnel for an arbitrary compute host.",
-    "notes": "Assumes a tunnel has already been set up for password-less login to localhost:22222",
-    "schemas": [
+      "local",
       "ssh"
     ],
     "ssh": {
-      "job_manager_endpoint": "ssh://rp@127.0.0.1:22222/",
-      "filesystem_endpoint": "sftp://rp@127.0.0.1:22222/"
+      "job_manager_endpoint": "ssh://rp@compute/",
+      "filesystem_endpoint": "sftp://rp@compute/"
+    },
+    "local": {
+      "job_manager_endpoint": "fork://localhost/",
+      "filesystem_endpoint": "file://localhost/"
     },
     "pre_bootstrap_1": [
     ],
@@ -48,8 +24,39 @@
     "agent_launch_method": "FORK",
     "task_launch_method": "FORK",
     "mpi_launch_method": "MPIEXEC",
-    "rp_version": "local",
-    "virtenv_mode": "create",
+    "rp_version": "installed",
+    "virtenv_mode": "use",
+    "virtenv": "/home/rp/rp-venv",
+    "python_dist": "default",
+    "cores_per_node": 4,
+    "gpus_per_node": 0,
+    "lfs_path_per_node": "/tmp",
+    "lfs_size_per_node": 1024,
+    "memory_per_node": 4096,
+    "fake_resources": true
+  },
+  "compute": {
+    "description": "compute service from the docker/stack.yml.",
+    "notes": "To use the ssh schema from outside of the Docker stack, make sure that ssh-agent has added the id_rsa.pub for the rp user in the scalems/radicalpilot image.",
+    "schemas": [
+      "ssh"
+    ],
+    "ssh": {
+      "job_manager_endpoint": "ssh://rp@compute/",
+      "filesystem_endpoint": "sftp://rp@compute/"
+    },
+    "pre_bootstrap_1": [],
+    "default_remote_workdir": "$HOME",
+    "resource_manager": "FORK",
+    "agent_config": "default",
+    "agent_scheduler": "CONTINUOUS",
+    "agent_spawner": "POPEN",
+    "agent_launch_method": "FORK",
+    "task_launch_method": "FORK",
+    "mpi_launch_method": "MPIEXEC",
+    "rp_version": "installed",
+    "virtenv_mode": "use",
+    "virtenv": "/home/rp/rp-venv",
     "python_dist": "default",
     "cores_per_node": 4,
     "gpus_per_node": 0,

--- a/docker/resource_local.json
+++ b/docker/resource_local.json
@@ -3,8 +3,13 @@
     "description": "GitHub Actions workflow with a `testenv` venv preconfigured.",
     "notes": "To use the ssh schema, make sure that ssh access to localhost is enabled.",
     "schemas": [
-      "local"
+      "local",
+      "ssh"
     ],
+    "ssh": {
+      "job_manager_endpoint": "ssh://127.0.0.1/",
+      "filesystem_endpoint": "sftp://127.0.0.1/"
+    },
     "local": {
       "job_manager_endpoint": "fork://localhost/",
       "filesystem_endpoint": "file://localhost/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,9 +346,12 @@ def _new_pilot(session: rp.Session,
         process = subprocess.run(
             ssh + ['/bin/echo', 'success'],
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             timeout=5,
             encoding='utf-8')
         if process.returncode != 0 or process.stdout.rstrip() != 'success':
+            logger.error('Failed ssh stdout: ' + str(process.stdout))
+            logger.error('Failed ssh stderr: ' + str(process.stderr))
             pytest.skip(f'Could not ssh to target computing resource with '
                         f'{" ".join(ssh)}.')
             return

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -65,7 +65,8 @@ def test_rp_basic_task_local(rp_task_manager, pilot_description):
 def test_rp_basic_task_remote(rp_task_manager, pilot_description):
     import radical.pilot as rp
 
-    if pilot_description.access_schema and pilot_description.access_schema == 'local':
+    if (pilot_description.access_schema and pilot_description.access_schema == 'local') \
+            or pilot_description.resource.startswith('local'):
         pytest.skip('This test is only for remote execution.')
 
     tmgr = rp_task_manager


### PR DESCRIPTION
Test local environment access via "ssh" as well as "local" access scheme.

Note: this still does not test true remote access. We should probably add that via a docker container so that we can continuously test environment preparation. However, testing with the `scalems/radicalpilot` docker image seems to indicate that remote tests are currently working.

Refs #134 