### PR TITLE
Update RCT required versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         python -m venv $HOME/testenv
         . $HOME/testenv/bin/activate
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -r requirements-testing.txt
+        python -m pip install --upgrade -r requirements-testing.txt
         python -m pip install .
         python -m pip install coverage pytest-cov
         radical-stack

--- a/docker/radicalpilot.dockerfile
+++ b/docker/radicalpilot.dockerfile
@@ -85,11 +85,13 @@ WORKDIR /home/rp
 # $HOME/Library/Application\ Support/JetBrains/Toolbox/apps/PyCharm-P/ch-0/211.7142.13/PyCharm.app/Contents/debug-eggs/
 RUN mkdir /tmp/scalems_dev
 
+RUN ~rp/rp-venv/bin/python -m pip install \
+    --no-cache-dir --no-build-isolation --upgrade 'radical.saga==1.6.6' 'radical.utils==1.6.6'
 #ARG RPREF="project/scalems"
 #RUN . ~rp/rp-venv/bin/activate && \
 #    pip install --no-cache-dir --no-build-isolation --upgrade "git+https://github.com/radical-cybertools/radical.pilot.git@${RPREF}#egg=radical.pilot"
-RUN . ~rp/rp-venv/bin/activate && \
-    pip install --no-cache-dir --no-build-isolation --upgrade 'radical.pilot==1.6.5'
+RUN ~rp/rp-venv/bin/python -m pip install \
+    --no-cache-dir --no-build-isolation --upgrade "https://github.com/radical-cybertools/radical.pilot/archive/53e85ea99345b6f50f3adfd975385be3200b750f.tar.gz"
 
 # WARNING!!! Security risk!
 # Allow rp user to trivially ssh into containers created from this image.

--- a/docker/rp-complete.dockerfile
+++ b/docker/rp-complete.dockerfile
@@ -85,7 +85,7 @@ RUN rp-venv/bin/pip install --upgrade \
 # Get repository for example and test files and to simplify RPREF build argument.
 # Note that GitHub may have a source directory name suffix that does not exactly
 # match the branch or tag name, so we use a glob to try to normalize the name.
-ARG RPREF="v1.6.5"
+ARG RPREF="v1.6.6"
 #ARG RPREF="project/scalems"
 # Note: radical.pilot does not work properly with an "editable install"
 RUN git clone -b $RPREF --depth=3 https://github.com/radical-cybertools/radical.pilot.git && \

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -17,7 +17,7 @@ setproctitle
 tox>=2.0
 
 # Use `pip install -r requirements-testing.txt --upgrade` to get branch updates.
-radical.saga==1.6.5
-radical.utils==1.6.5
-radical.pilot==1.6.5
-# git+https://github.com/radical-cybertools/radical.pilot.git@ffce7b49217f8568abba13623b7cd1e2bc5d833d
+radical.saga==1.6.6
+radical.utils==1.6.6
+# radical.pilot==1.6.6
+https://github.com/radical-cybertools/radical.pilot/archive/53e85ea99345b6f50f3adfd975385be3200b750f.tar.gz

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,13 +21,13 @@ packages = find:
 package_dir =
     =src
 install_requires =
-    radical.pilot>=1.6.5
+    radical.pilot>=1.6.6
 tests_require =
     build
     pytest>=6.1.2
     pytest-asyncio>=0.14
     pytest-env
-    radical.pilot>=1.6.5
+    radical.pilot>=1.6.6
 
 [options.entry_points]
 console_scripts =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     # It is not an error to run tests without RP, but when RP is available, we
     # need to import it before pytest imports the logging module.
-    ...
+    rp = None
 
 import logging
 import os
@@ -43,14 +43,7 @@ from importlib import metadata
 from packaging import version
 
 ru_version = version.parse(metadata.version('radical.utils'))
-if ru_version < version.parse('1.6.6'):
-    import radical.utils
-    import socket
-
-    radical.utils.misc._hostname = socket.gethostname()
-else:
-    assert ru_version >= version.parse('1.6.6')
-    warnings.warn('Unnecessary monkey-patch of radical.utils.misc.', DeprecationWarning)
+assert ru_version >= version.parse('1.6.6')
 
 logger = logging.getLogger('pytest_config')
 logger.setLevel(logging.DEBUG)

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -225,8 +225,9 @@ async def test_rp_future(rp_task_manager):
     assert wrapper.cancelled()
     assert future.cancelled()
 
-    # WARNING: rp.Task.wait() never completes with no arguments.
     # WARNING: This blocks. Don't do it in the event loop thread.
+    # TODO: Check whether the following is still true.
+    # WARNING: rp.Task.wait() never completes with no arguments (issue #87).
     task.wait(state=rp.states.CANCELED, timeout=120)
     # Note that if the test is paused by a debugger, the rp task may
     # have a chance to complete before being canceled.
@@ -252,8 +253,9 @@ async def test_rp_future(rp_task_manager):
     assert not wrapper.cancelled()
     assert future.cancelled()
 
-    # WARNING: rp.Task.wait() never completes with no arguments.
     # WARNING: This blocks. Don't do it in the event loop thread.
+    # TODO: Check whether the following is still true.
+    # WARNING: rp.Task.wait() never completes with no arguments (issue #87).
     task.wait(state=rp.states.CANCELED, timeout=120)
     # Note that if the test is paused by a debugger, the rp task may
     # have a chance to complete before being canceled.
@@ -387,7 +389,8 @@ def test_rp_raptor_staging(pilot_description, rp_venv):
         # (see https://docs.google.com/drawings/d/1q5ehxIVdln5tXEn34mJyWAmxBk_DqZ5wwkl3En-t5jo/)
 
         # Confirm that Master script is running (and ready to receive raptor tasks)
-        # WARNING: rp.Task.wait() *state* parameter does not handle tuples, but does not check type.
+        # WARNING: rp.Task.wait() *state* parameter does not handle tuples,
+        #  but does not check type (RP issue tracking?).
         master.wait(state=[rp.states.AGENT_EXECUTING] + rp.FINAL)
         assert master.state not in {rp.CANCELED, rp.FAILED}
 

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -390,7 +390,7 @@ def test_rp_raptor_staging(pilot_description, rp_venv):
 
         # Confirm that Master script is running (and ready to receive raptor tasks)
         # WARNING: rp.Task.wait() *state* parameter does not handle tuples,
-        #  but does not check type (RP issue tracking?).
+        #  but does not check type.
         master.wait(state=[rp.states.AGENT_EXECUTING] + rp.FINAL)
         assert master.state not in {rp.CANCELED, rp.FAILED}
 


### PR DESCRIPTION
Use 1.6.6 and remove the workaround for radical.utils.

Also pin radical.pilot to 53e85ea99345b6f50f3adfd975385be3200b750f (branch `project/scalems`) prior to exploring some outstanding issues which may have been resolved.

Follow-up PRs will check whether we can re-enable tests that were blocked by problems relating to issues #87, #89, #90, and #119.