### PR TITLE
Add missing dependency on `packaging` package.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,11 @@ packages = find:
 package_dir =
     =src
 install_requires =
+    packaging
     radical.pilot>=1.6.6
 tests_require =
     build
+    packaging
     pytest>=6.1.2
     pytest-asyncio>=0.14
     pytest-env


### PR DESCRIPTION
We used to be able to rely on `packaging` to be provided with
`setuptools`, but this may not be the case. Make `packaging` an explicit
 dependency.