### PR TITLE
Use codecov API token.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         files: ./coverage1.xml,./coverage2.xml
         name: codecov-local-${{ matrix.python-version }}
@@ -117,6 +118,7 @@ jobs:
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         files: ./coverage1.xml,./coverage2.xml
         name: codecov-rp-local-${{ matrix.python-version }}
@@ -202,6 +204,7 @@ jobs:
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         files: ./coverage1.xml,./coverage2.xml
         name: codecov-rp-ssh-${{ matrix.python-version }}


### PR DESCRIPTION
This is not supposed to be required for public repositories, but the feedback from some recent failed jobs indicates that it may still be useful to improve the robustness of API calls between GitHub Actions and codecov infrastructure.