### PR TITLE
Add more software to Docker images.

### DIFF
--- a/docker/rp-complete.dockerfile
+++ b/docker/rp-complete.dockerfile
@@ -69,6 +69,7 @@ RUN rp-venv/bin/pip install --upgrade \
         setuptools \
         wheel && \
     rp-venv/bin/pip install --upgrade \
+        build \
         coverage \
         flake8 \
         'mock==2.0.0' \

--- a/docker/scalems-lammps.dockerfile
+++ b/docker/scalems-lammps.dockerfile
@@ -39,7 +39,7 @@ FROM scalems/rp-complete:$TAG
 USER rp
 WORKDIR /home/rp
 
-RUN ./rp-venv/bin/pip install --upgrade pip setuptools
+RUN ./rp-venv/bin/pip install --upgrade pip setuptools wheel
 
 COPY --chown=rp:radical . scalems
 
@@ -55,6 +55,7 @@ RUN apt-get update && \
         apt-utils \
         build-essential \
         cmake \
+        fftw3 \
         git \
         libopenmpi-dev \
         make \

--- a/docker/scalems-lammps.dockerfile
+++ b/docker/scalems-lammps.dockerfile
@@ -1,0 +1,69 @@
+# Extend base scalems testing image with a lammps installation.
+#
+# Summary:
+#     docker build -t scalems/lammps -f scalems-lammps.dockerfile ../..
+#     docker run --rm -ti scalems/lammps bash
+#
+# Note that the image takes a while to build the first time. To try to use build
+# cache from an existing image, try:
+#     docker pull scalems/radicalpilot
+#     docker pull scalems/lammps
+#     docker build -t scalems/lammps --cache-from scalems/lammps ../..
+#
+# Example usage:
+#     docker run --rm -ti scalems/lammps bash
+#     $ . ./rp-venv/bin/activate
+# Note that, because of the `--rm` flag, the container will be removed when you
+# exit the containerized shell.
+
+FROM scalems/radicalpilot
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-suggests --no-install-recommends \
+        apt-utils \
+        build-essential \
+        cmake \
+        git \
+        libopenmpi-dev \
+        make \
+        ninja-build \
+        pkg-config \
+        software-properties-common \
+        vim \
+        wget \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+USER rp
+
+# Patch release will have a path like lammps-27May2021
+RUN . $HOME/rp-venv/bin/activate && \
+    mkdir /tmp/lammps && \
+    cd /tmp/lammps && \
+    wget https://download.lammps.org/tars/lammps.tar.gz && \
+    tar xvf lammps.tar.gz && \
+    cd lammps-* && \
+    mkdir build && \
+    cd build && \
+    cmake ../cmake -G Ninja \
+        -DPKG_KSPACE=yes \
+        -DPKG_MOLECULE=yes \
+        -DPKG_MPIIO=yes \
+        -DPKG_PYTHON=yes \
+        -DPKG_REPLICA=yes \
+        -DPKG_MISC=yes \
+        -DPKG_GPU=yes \
+        -DPKG_COMPRESS=yes \
+        && \
+    cmake --build . && \
+    cmake --build . --target install
+
+#ENV REF=master
+#
+#RUN . $EXAMPLE/env38/bin/activate && \
+#    pip install --upgrade scalems@git+https://github.com/SCALE-MS/scale-ms.git@$REF
+
+#COPY --chown=rp:radical examples/basic_gmxapi/*.py $EXAMPLE/examples/basic_gmxapi/
+#COPY --chown=rp:radical testdata $EXAMPLE/testdata
+

--- a/docker/scalems-lammps.dockerfile
+++ b/docker/scalems-lammps.dockerfile
@@ -57,7 +57,8 @@ RUN . $HOME/rp-venv/bin/activate && \
         -DPKG_COMPRESS=yes \
         && \
     cmake --build . && \
-    cmake --build . --target install
+    cmake --build . --target install && \
+    rm -rf /tmp/lammps
 
 #ENV REF=master
 #

--- a/docker/scalems-lammps.dockerfile
+++ b/docker/scalems-lammps.dockerfile
@@ -36,17 +36,6 @@
 ARG TAG=latest
 FROM scalems/rp-complete:$TAG
 
-USER rp
-WORKDIR /home/rp
-
-RUN ./rp-venv/bin/pip install --upgrade pip setuptools wheel
-
-COPY --chown=rp:radical . scalems
-
-RUN ./rp-venv/bin/pip install --upgrade -r scalems/requirements-testing.txt
-RUN ./rp-venv/bin/pip install scalems/
-# The current rp and scalems packages should now be available to the rp user in /home/rp/rp-venv
-
 USER root
 
 RUN apt-get update && \
@@ -55,7 +44,7 @@ RUN apt-get update && \
         apt-utils \
         build-essential \
         cmake \
-        fftw3 \
+        libfftw3-dev \
         git \
         libopenmpi-dev \
         make \
@@ -68,6 +57,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 USER rp
+
+WORKDIR /home/rp
+
+RUN /home/rp/rp-venv/bin/pip install --upgrade pip setuptools wheel
+RUN /home/rp/rp-venv/bin/pip install --upgrade cmake
 
 # Patch release will have a path like lammps-27May2021
 RUN . $HOME/rp-venv/bin/activate && \
@@ -91,6 +85,12 @@ RUN . $HOME/rp-venv/bin/activate && \
     cmake --build . && \
     cmake --build . --target install && \
     rm -rf /tmp/lammps
+
+COPY --chown=rp:radical . scalems
+
+RUN ./rp-venv/bin/pip install --upgrade -r scalems/requirements-testing.txt
+RUN ./rp-venv/bin/pip install scalems/
+# The current rp and scalems packages should now be available to the rp user in /home/rp/rp-venv
 
 #ENV REF=master
 #


### PR DESCRIPTION
Start by building an image with a lammps installation.

Install to default location: /home/rp/.local

In a follow-up, we can consider whether to copy this into the base
scalems/radicalpilot image or consider alternatives.