### PR TITLE
Further simplify CLI parser.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ release = '0'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinxcontrib.autoprogram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',  # Note: todo_include_todos=True is required for directives to produce output.
     'sphinxcontrib.napoleon',

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -143,7 +143,22 @@ Workflow
 Backends
 --------
 
-See `backend` for user facing module interfaces.
+See :doc:`invocation` for user facing module interfaces.
+
+Built-in Execution Modules include `scalems.radical` and `scalems.local`
+
+For command line usage, an `backend` should support interaction with the
+`scalems.invocation` module.
+
+Support for module authors
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scalems.invocation
+    :members:
+
+.. autofunction:: scalems.utility.parser
+
+.. autofunction:: scalems.utility.make_parser
 
 Extra scalems.radical details
 -----------------------------
@@ -151,8 +166,6 @@ Extra scalems.radical details
 .. autoclass:: scalems.radical.Configuration
 
 .. autofunction:: scalems.radical.configuration
-
-.. autofunction:: scalems.radical.parser
 
 scalems.radical.runtime support module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ for data flow driven molecular simulation management and analysis.
     :maxdepth: 2
 
     install
+    invocation
     userguide
     developer
     python

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -56,7 +56,7 @@ or *local* :py:data:`~radical.pilot.PilotDescription.access_schema`)
 then you can execute in the same venv used on the client side.
 Otherwise, you will need to prepare a virtual environment
 (accessible to the chosen `RP resource`_) and inform `scalems.radical` of it
-at run time. (See :option:`--venv`)
+at run time. (See :option:`scalems.radical --venv`)
 
 When executing the workflow, `scalems.radical` will automatically direct RP to *activate*
 the chosen virtual environment before launching Tasks.

--- a/docs/invocation.rst
+++ b/docs/invocation.rst
@@ -1,0 +1,62 @@
+===================
+SCALE-MS invocation
+===================
+
+Users define and execute SCALE-MS workflows by using Python to define work and
+submit it for execution through a SCALE-MS workflow manager.
+The SCALE-MS machinery is accessible through the :py:mod:`scalems` Python module.
+
+For the greatest flexibility in execution, scripts should be written without
+explicit reference to the execution environment. Instead, a SCALE-MS workflow
+manager :ref:`backend` can be specified on the command line to bootstrap an entry point.
+
+:command:`python3 -m scalems.local myscript.py`
+would use the workflow manager provided by the :py:mod:`scalems.local`
+module to process :file:`myscript.py`. After the module performs some initialization,
+the script is essentially just imported. After that, though, specifically annotated
+callables (functions or function objects) are identified and submitted for execution.
+See :py:func:`scalems.app`.
+
+Command line execution
+======================
+
+Use the ``--help`` command line option for an execution module for details about
+available and required command line arguments::
+
+    $ python -m scalems.local --help
+    usage: python -m scalems.local <scalems.local args> script-to-run.py.py <script args>
+    ...
+
+The base command line parser is provided by :py:func:`scalems.utility.parser`,
+extended (optionally) by the :ref:`backend`, and further extended by
+:py:func:`scalems.invocation.run`. Get usage for a particular backend with
+reference to the particular module.
+
+    python3 -m scalems.local --help
+
+Unrecognized command line arguments will be passed along to the called script.
+
+Documentation for built-in execution modules is shown below.
+Documentation also may be accessed from the command line with
+`pydoc <https://docs.python.org/3/library/pydoc.html>`__
+or from within the interpreter with :py:func:`help`.
+(E.g. ``pydoc scalems.radical``)
+
+.. autoprogram:: scalems.local:parser
+
+.. automodule:: scalems.local
+
+.. autoprogram:: scalems.radical:parser
+
+.. automodule:: scalems.radical
+
+Pure Python execution
+=====================
+
+For some use cases (such as Jupyter notebooks), it may be preferable to configure the execution target and launch
+a workflow entirely from within Python.
+
+Such use cases are not yet well-supported in `scalems`.
+
+Refer to the `test suite <https://github.com/SCALE-MS/scale-ms/tree/master/tests>`__ for examples,
+or follow https://github.com/SCALE-MS/scale-ms/issues/82

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -87,6 +87,14 @@ See :doc:`invocation` for usage information.
 
 See :py:mod:`scalems.invocation` for more about Execution Modules.
 
+Entry point
+===========
+
+The entry point for a `scalems` workflow script is the function decorated with
+`scalems.app`
+
+.. autodecorator:: scalems.app
+
 Basic functions
 ===============
 

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -82,28 +82,10 @@ Workflows may be executed through different means and with different resources
 through distinct modules. Different middleware implementations may be accessed
 directly, but we recommend selecting a management module when invoking Python
 from the command line with the ``-m`` option.
-Use the ``--help`` command line option for an execution module for details about
-available and required command line arguments::
 
-    $ python -m scalems.local --help
-    usage: python -m scalems.local <scalems.local args> script-to-run.py.py <script args>
-    ...
+See :doc:`invocation` for usage information.
 
-Documentation for built-in execution modules is shown below,
-but may be accessed from the command line with
-`pydoc <https://docs.python.org/3/library/pydoc.html>`__
-or from within the interpreter with :py:func:`help`.
-(E.g. ``pydoc scalems.radical``)
-
-scalems.local
--------------
-
-.. automodule:: scalems.local
-
-scalems.radical
----------------
-
-.. automodule:: scalems.radical
+See :py:mod:`scalems.invocation` for more about Execution Modules.
 
 Basic functions
 ===============

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+sphinx>=2
 sphinxcontrib-autoprogram
 sphinxcontrib-napoleon
 sphinxcontrib-plantuml

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+sphinxcontrib-autoprogram
 sphinxcontrib-napoleon
 sphinxcontrib-plantuml
 sphinx-rtd-theme

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -11,10 +11,7 @@ RADICAL Pilot, which has additional requirements.
 
 See :doc:`install`
 
-Invocation
-==========
-
-.. automodule:: scalems.invocation
+For the basics of running SCALE-MS scripts, see :doc:`invocation`.
 
 Idioms
 ======

--- a/src/scalems/local/__init__.py
+++ b/src/scalems/local/__init__.py
@@ -8,8 +8,6 @@ Example:
     python3 -m scalems.local my_workflow.py
 
 """
-# TODO: Consider converting to a namespace package to improve modularity of
-#  implementation.
 
 import asyncio
 import importlib
@@ -26,13 +24,13 @@ from ..exceptions import MissingImplementationError
 from ..exceptions import ProtocolError
 from ..identifiers import TypeIdentifier
 from ..subprocess._subprocess import SubprocessTask
+from scalems.utility import make_parser as _make_parser
 
 logger = logging.getLogger(__name__)
 logger.debug('Importing {}'.format(__name__))
 
 
-# TO DO NEXT: Implement the queue, dispatcher, executor (and internal queue)
-# and, come on... add the fingerprinter... and the basic serializer...  `
+parser = _make_parser(__package__)
 
 
 def workflow_manager(loop: asyncio.AbstractEventLoop):

--- a/src/scalems/radical/__init__.py
+++ b/src/scalems/radical/__init__.py
@@ -8,20 +8,6 @@ Command Line Invocation Example:
 For required and optional command line arguments:
     ``python -m scalems.radical --help``
 
-Command Line Arguments:
-    .. option:: --resource <name>
-
-        Name of a defined RADICAL Pilot execution resource.
-        See also `RP resource`. (Required)
-
-    .. option:: --venv <path>
-
-        Path to the Python virtual environment with which tasks should be executed.
-        (Required. See also https://github.com/SCALE-MS/scale-ms/issues/90)
-
-    Additional arguments may provide configuration fields for the `radical.pilot.Pilot`
-    or other `radical.pilot <https://radicalpilot.readthedocs.io/en/stable/>`__ components.
-
 The user is largely responsible for establishing appropriate
 `RADICAL Cybertools <https://radical-cybertools.github.io/>`__
 (RCT) software environment at both the client side
@@ -106,6 +92,7 @@ from .runtime import get_pre_exec
 from .runtime import parser as _runtime_parser
 from .runtime import Runtime
 from ..identifiers import TypeIdentifier
+from scalems.utility import make_parser as _make_parser
 
 logger = logging.getLogger(__name__)
 logger.debug('Importing {}'.format(__name__))
@@ -117,23 +104,7 @@ except AttributeError:
     cache = functools.lru_cache(maxsize=None)
 
 
-@cache
-def parser(add_help=False):
-    """Get the module-specific argument parser.
-
-    Provides a base argument parser for scripts using the scalems.radical backend.
-
-    By default, the returned ArgumentParser is created with ``add_help=False``
-    to avoid conflicts when used as a *parent* for a parser more local to the caller.
-    If *add_help* is provided, it is passed along to the ArgumentParser created
-    in this function.
-
-    See Also:
-         https://docs.python.org/3/library/argparse.html#parents
-    """
-    _parser = argparse.ArgumentParser(add_help=add_help, parents=[_runtime_parser()])
-    # We don't yet have anything to add...
-    return _parser
+parser = _make_parser(__package__, parents=[_runtime_parser()])
 
 
 def configuration(*args, **kwargs) -> Configuration:
@@ -158,7 +129,7 @@ def configuration(*args, **kwargs) -> Configuration:
     elif _configuration.get(None) is None:
         # No config is set yet. Generate with module parser.
         c = Configuration()
-        parser().parse_known_args(namespace=typing.cast(argparse.Namespace, c))
+        parser.parse_known_args(namespace=typing.cast(argparse.Namespace, c))
         _configuration.set(c)
     return _configuration.get()
 

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -96,13 +96,15 @@ def parser(add_help=False):
                          metavar='PATH',
                          type=str,
                          required=True,
-                         help='Full path to a (pre-configured) venv to use for RP tasks.')
+                         help='tasks.Path to the (pre-configured) Python virtual '
+                              'environment with which RP tasks should be executed. '
+                              '(Required. See also https://github.com/SCALE-MS/scale-ms/issues/90)')
 
     _parser.add_argument(
         '--resource',
         type=str,
         required=True,
-        help='Specify a *resource* for the radical.pilot.PilotDescription.'
+        help='Specify a `RP resource` for the radical.pilot.PilotDescription. (Required)'
     )
 
     _parser.add_argument(
@@ -116,7 +118,7 @@ def parser(add_help=False):
         action='append',
         type=_parse_option,
         metavar='<key>=<value>',
-        help='Add a key value pair to the pilot description.'
+        help='Add a key value pair to the `radical.pilot.PilotDescription`.'
     )
     return _parser
 
@@ -126,9 +128,9 @@ class Configuration:
     """Module configuration information.
 
     See also:
-        `scalems.radical.configuration`
-        `scalems.radical.parser`
-        `scalems.radical.runtime.Runtime`
+        :py:func:`scalems.radical.configuration`
+        :py:data:`scalems.radical.parser`
+        :py:class:`scalems.radical.runtime.Runtime`
 
     TODO: Consider merging with module Runtime state container.
     """

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -128,9 +128,9 @@ class Configuration:
     """Module configuration information.
 
     See also:
-        :py:func:`scalems.radical.configuration`
-        :py:data:`scalems.radical.parser`
-        :py:class:`scalems.radical.runtime.Runtime`
+        * :py:func:`scalems.radical.configuration`
+        * :py:data:`scalems.radical.runtime.parser`
+        * :py:class:`scalems.radical.runtime.Runtime`
 
     TODO: Consider merging with module Runtime state container.
     """

--- a/src/scalems/utility.py
+++ b/src/scalems/utility.py
@@ -4,6 +4,7 @@ __all__ = [
     'app',
     'command',
     'function_wrapper',
+    'make_parser',
     'parser',
     'poll',
     'wait',
@@ -73,6 +74,40 @@ def parser(add_help=False):
         help='Attempt to connect to PyCharm remote debugging system, where appropriate.'
     )
 
+    _parser.add_argument(
+        'script',
+        metavar='script-to-run.py',
+        type=str,
+    )
+
+    return _parser
+
+
+def make_parser(module: str, parents: typing.Iterable[argparse.ArgumentParser] = None):
+    """Make a SCALE-MS Execution Module command line argument parser.
+
+    Args:
+        module: Name of the execution module.
+        parents: Optional list of parent parsers.
+
+    If *parents* is not provided, `scalems.utility.parser` is used to generate a default.
+    If *parents* _is_ provided, one of the provided parents **should** inherit from
+    `scalems.utility.parser` using the *parents* parameter of
+    :py:class:`argparse.ArgumentParser`.
+
+    Notes:
+        :py:data:`__package__` and :py:data:`__module__` are convenient aliases that a
+        client might use to provide the *module* argument.
+    """
+    if parents is None:
+        parents = [parser()]
+    _parser = argparse.ArgumentParser(
+        prog=module,
+        description=f'Process {module} command line arguments.',
+        usage=f'python -m {module} <{module} args> script-to-run.py.py '
+              '<script args>',
+        parents=parents
+    )
     return _parser
 
 

--- a/src/scalems/utility.py
+++ b/src/scalems/utility.py
@@ -78,6 +78,7 @@ def parser(add_help=False):
         'script',
         metavar='script-to-run.py',
         type=str,
+        help='The workflow script. Must contain a function decorated with `scalems.app`'
     )
 
     return _parser


### PR DESCRIPTION
* Expand documentation and provide the make_parser() utility.
* Include full CLI documentation.
* Separate CLI documentation from Python module documentation.
* Rely more on docstrings and cross-link where possible.
* Preserve separation of developer docs from user docs while publishing more module docs.
