### PR TITLE
Handle a race condition.

### DIFF
--- a/src/scalems/radical/__init__.py
+++ b/src/scalems/radical/__init__.py
@@ -71,6 +71,7 @@ import os
 import pathlib
 import threading
 import typing
+import weakref
 
 from radical import pilot as rp
 
@@ -202,7 +203,10 @@ class RPFinalTaskState:
         return self.canceled.is_set() or self.done.is_set() or self.failed.is_set()
 
 
-def _rp_callback(obj: rp.Task, state, final: RPFinalTaskState):
+def _rp_callback(obj: rp.Task,
+                 state,
+                 cb_data: weakref.ReferenceType = None,
+                 final: RPFinalTaskState = None):
     """Prototype for RP.Task callback.
 
     To use, partially bind the *final* parameter (with functools.partial) to get a
@@ -210,12 +214,18 @@ def _rp_callback(obj: rp.Task, state, final: RPFinalTaskState):
 
     Register with *task* to be called when the rp.Task state changes.
     """
+    if final is None:
+        raise APIError('This function is strictly for dynamically prepared RP callbacks through functools.partial.')
     logger.debug(f'Callback triggered by {repr(obj)} state change to {repr(state)}.')
     try:
         # Note: assertions and exceptions are not useful in RP callbacks.
-        # TODO: Can/should we register the call-back just for specific states?
         if state in (rp.states.DONE, rp.states.CANCELED, rp.states.FAILED):
-            # TODO: unregister call-back with RP Task or redirect subsequent call-backs.
+            # TODO: Pending https://github.com/radical-cybertools/radical.pilot/issues/2444
+            # tmgr: rp.TaskManager = obj.tmgr
+            # ref = cb_data()
+            # tmgr.unregister_callback(cb=ref, metrics='TASK_STATE',
+            #                          uid=obj.uid)
+            logger.debug(f'Recording final state {state} for {repr(obj)}')
             if state == rp.states.DONE:
                 final.done.set()
             elif state == rp.states.CANCELED:
@@ -229,7 +239,8 @@ def _rp_callback(obj: rp.Task, state, final: RPFinalTaskState):
 
 
 async def _rp_task_watcher(task: rp.Task,  # noqa: C901
-                           future: asyncio.Future, final: RPFinalTaskState,
+                           future: asyncio.Future,
+                           final: RPFinalTaskState,
                            ready: asyncio.Event) -> rp.Task:
     """Manage the relationship between an RP.Task and a scalems Future.
 
@@ -241,6 +252,7 @@ async def _rp_task_watcher(task: rp.Task,  # noqa: C901
     Arguments:
         task: RADICAL Pilot Task, submitted by caller.
         future: asyncio.Future to which *task* results should be propagated.
+        final: thread-safe event handler for the RP task call-back to announce it has run.
         ready: output parameter, set when coroutine has run enough to perform its
         responsibilities.
 
@@ -307,8 +319,10 @@ async def _rp_task_watcher(task: rp.Task,  # noqa: C901
                 return task
             if task.state in (rp.states.DONE, rp.states.CANCELED, rp.states.FAILED):
                 if not final:
-                    logger.debug(f'RP Task {task.uid} complete, but Event not '
-                                 'triggered. Possible race condition.')
+                    logger.debug(f'RP Task {task.uid} is in state {task.state}, '
+                                 'but Event not triggered. Possible race condition.'
+                                 'If we see this log message, we need to make sure that the Future is getting correctly set.')
+
     except asyncio.CancelledError as e:
         logger.debug(
             'Propagating scalems manager task cancellation to scalems future and rp '
@@ -354,7 +368,12 @@ async def rp_task(rptask: rp.Task, future: asyncio.Future) -> asyncio.Task:
     final = RPFinalTaskState()
     callback = functools.partial(_rp_callback, final=final)
     functools.update_wrapper(callback, _rp_callback)
-    rptask.register_callback(callback)
+
+    # Note: register_callback() does not provide a return value to use for
+    # TaskManager.unregister_callback.
+    cb_data: weakref.ReferenceType = weakref.ref(callback)
+
+    rptask.register_callback(callback, cb_data=cb_data, metric=rp.constants.TASK_STATE)
 
     asyncio.get_running_loop().slow_callback_duration = 0.2
     watcher_started = asyncio.Event()

--- a/src/scalems/radical/raptor.py
+++ b/src/scalems/radical/raptor.py
@@ -1,0 +1,117 @@
+"""
+Define the connective tissue for SCALE-MS tasks embedded in rp.Task arguments.
+"""
+
+import typing
+
+import radical.pilot as rp
+
+
+_RaptorReturnType = typing.Tuple[typing.Text, typing.Text, typing.SupportsInt]
+"""Raptor worker task return values are interpreted as a tuple (out, err, ret).
+
+The first two elements are cast to output and error strings, respectively.
+
+The third is cast to an integer return code.
+"""
+
+_RaptorWorkData = typing.TypeVar('_RaptorWorkData')
+"""Argument type for a Raptor task implementation.
+
+Constraints on the data type are not yet well-defined.
+Presumably, the object must be "Munch"-able.
+"""
+
+
+_DataT = typing.TypeVar('_DataT')
+
+
+class ScaleMSTaskDescription(typing.TypedDict):
+    """SCALE-MS specialization of extra raptor task info.
+
+    This structure is serialized into the TaskDescription.arguments[0] of a rp.Task
+    submitted with a *scheduler* set to a ``scalems_rp_master`` Task uid.
+
+    When deserialized, the object is treated as the prototype for a _RequestInput.
+
+    The mapping is assumed to contain keys *mode*, *data*, and *timeout*
+    when it becomes incorporated into a new Request object (as the core
+    data member) after Master.request_cb(). Optionally, it may contain
+    *cores* and *gpus*.
+    """
+    mode: str
+    data: typing.Any
+    timeout: typing.SupportsFloat
+    cores: typing.Optional[int]
+    gpus: typing.Optional[int]
+
+
+class _RequestInput(typing.TypedDict):
+    """Input argument for a raptor.Request instantiation.
+
+    Not yet fully specified, but not to be confused with
+    raptor.Request instances.
+
+    A dict-like object with at least a *uid* key.
+
+    As of RP 1.6.7, the RequestInput is dict-like object deserialized
+    from the wrapper TaskDescription *arguments* member's first element.
+    After deserialization, the dict is assigned values for *is_task*,
+    *uid*, and *task*.
+
+    The mapping is assumed to contain keys *mode*, *data*, and *timeout*
+    when it becomes incorporated into a new Request object (as the core
+    data member) after Master.request_cb(). Optionally, it may contain
+    *cores* and *gpus*.
+    """
+    is_task: bool
+    uid: str
+    task: rp.Task
+    mode: str
+    data: typing.Any
+    timeout: typing.SupportsFloat
+    cores: typing.Optional[int]
+    gpus: typing.Optional[int]
+
+
+class ScaleMSRequestInput(_RequestInput, ScaleMSTaskDescription):
+    """"""
+
+
+class RaptorWorkCallable(typing.Protocol[_RaptorWorkData]):
+    def __call__(self, data: _RaptorWorkData) -> _RaptorReturnType:
+        ...
+
+
+class RaptorWorkDescription(typing.Protocol[_RaptorWorkData]):
+    """Represent the content of an *arguments* element in a RaptorTaskDescription.
+
+    A dictionary resembling this structure is converted to radical.pilot.raptor.Request
+    by the Master in radical.pilot.raptor.Master.request().
+
+    Attributes:
+        mode (str): Dispatching key for raptor.Worker._dispatch()
+
+    Note that some keys may be added or overwritten during Master._receive_tasks
+    (e.g. *is_task*, *uid*, *task*).
+    """
+    cores: int
+    timeout: typing.SupportsFloat
+    mode: str  # Must map to a mode (RaptorWorkCallable) in the receiving Worker._modes
+    data: _RaptorWorkData  # Munch-able object to be passed to Worker._modes[*mode*](*data*)
+
+
+class _RaptorTaskDescription(typing.Protocol):
+    """Note the distinctions of a TaskDescription to processed by a raptor.Master.
+
+
+    The single element of *arguments* is a JSON-encoded object that will be
+    deserialized (RaptorWorkDescription) as the prototype for the dictionary used to instantiate the Request.
+    """
+    uid: str  # Unique identifier for the Task across the Session.
+    executable: typing.ClassVar[str] = 'scalems'  # Unused by Raptor tasks.
+    scheduler: str  # The UID of the raptor.Master scheduler task.
+    arguments: typing.Sequence[str]  # Processed by raptor.Master._receive_tasks
+
+
+RequestInputList = typing.List[_RequestInput]

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -506,36 +506,6 @@ def _connect_rp(config: Configuration) -> Runtime:
         logger.debug('Got Pilot {}'.format(pilot.uid))
         runtime.pilot(pilot)
 
-        # Note that the task description for the master (and worker) can specify a
-        # *named_env* attribute to use a venv prepared via Pilot.prepare_env
-        # E.g.         pilot.prepare_env({'numpy_env' : {'type'   : 'virtualenv',
-        #                                           'version': '3.6',
-        #                                           'setup'  : ['numpy']}})
-        #   td.named_env = 'numpy_env'
-        # Note that td.named_env MUST be a key that is given to pilot.prepare_env(arg:
-        # dict) or the task will wait indefinitely to be scheduled.
-        # Alternatively, we could use a pre-installed venv by putting
-        # `. path/to/ve/bin/activate`
-        # in the TaskDescription.pre_exec list.
-
-        # TODO: Use archives generated from (acquired through) the local installations.
-        # # Could we stage in archive distributions directly?
-        # # self.pilot.stage_in()
-        # pilot.prepare_env(
-        #     {
-        #         'scalems_env': {
-        #             'type': 'virtualenv',
-        #             'version': '3.8',
-        #             'setup': [
-        #                 # TODO: Generalize scalems dependency resolution.
-        #                 # Ideally, we would check the current API version
-        #                 # requirement, map that to a package version,
-        #                 # and specify >=min_version, allowing cached archives to
-        #                 # satisfy the dependency.
-        #                 rp_spec,
-        #                 scalems_spec
-        #             ]}})
-
         task_manager.add_pilots(pilot)
         logger.debug('Added Pilot {} to task manager {}.'.format(
             pilot.uid,

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -312,6 +312,23 @@ class Runtime:
                 return self.pilot(pilot)
 
 
+@cache
+def _master_script() -> str:
+    try:
+        import pkg_resources
+    except ImportError:
+        pkg_resources = None
+    master_script = 'scalems_rp_master'
+    if pkg_resources is not None:
+        # It is not hugely important if we cannot perform this test.
+        # In reality, this should be performed at the execution site, and we can/should
+        # remove the check here once we have effective API compatibility checking.
+        # See https://github.com/SCALE-MS/scale-ms/issues/100
+        assert pkg_resources.get_entry_info('scalems', 'console_scripts',
+                                            'scalems_rp_master').name == master_script
+    return master_script
+
+
 def _get_scheduler(name: str,
                    pre_exec: typing.Iterable[str],
                    task_manager: rp.TaskManager):
@@ -330,11 +347,22 @@ def _get_scheduler(name: str,
         Currently there is no completion condition for the master script.
         Caller is responsible for canceling the Task returned by this function.
     """
+    # define a raptor.scalems master and launch it within the pilot
+    td = rp.TaskDescription()
+    td.uid = name
+
     # This is the name that should be resolvable in an active venv for the script we
     # install as
     # pkg_resources.get_entry_info('scalems', 'console_scripts', 'scalems_rp_master').name
-    master_script = 'scalems_rp_master'
+    master_script = _master_script()
 
+    td.executable = master_script
+
+    # Note: As of RP 1.6.7, the rp.radical.Master still accepts an optional config
+    # filename argument, but its use and future disposition are fluid and unclear.
+    # We do not seem to need one at the moment. If we do, it may end up looking
+    # something like the following.
+    #
     # We can probably make the config file a permanent part of the local metadata,
     # but we don't really have a scheme for managing local metadata right now.
     # with tempfile.TemporaryDirectory() as dir:
@@ -343,17 +371,16 @@ def _get_scheduler(name: str,
     #     with open(config_file_path, 'w') as fh:
     #         encoded = scalems_rp_master.encode_as_dict(scheduler_config)
     #         json.dump(encoded, fh, indent=2)
-
-    # define a raptor.scalems master and launch it within the pilot
-    td = rp.TaskDescription(
-        {
-            'uid': name,
-            'executable': master_script
-        })
     td.arguments = []
+
     td.pre_exec = pre_exec
+    # We are not using prepare_env at this point. We use the `venv` configured by the
+    # caller.
     # td.named_env = 'scalems_env'
     logger.debug('Launching RP scheduler.')
+
+    # WARNING: The following line may block for several seconds. Consider using a
+    # separate thread (if RP supports it).
     scheduler = task_manager.submit_tasks(td)
     # WARNING: rp.Task.wait() *state* parameter does not handle tuples, but does not
     # check type.
@@ -371,8 +398,8 @@ def _get_scheduler(name: str,
 def _connect_rp(config: Configuration) -> Runtime:
     """Establish the RP Session.
 
-    Acquire as many re-usable resources as possible. The scope established by
-    this function is as broad as it can be within the life of this instance.
+    Acquire a maximally re-usable set of RP resources. The scope established by
+    this function is as broad as it can be within the life of the workflow manager.
 
     Once instance._connect_rp() succeeds, instance._disconnect_rp() must be called to
     clean up resources. Use the async context manager behavior of the instance to
@@ -392,14 +419,21 @@ def _connect_rp(config: Configuration) -> Runtime:
     # A non-async method is potentially useful for debugging, but causes the event loop
     # to block while waiting for the RP tasks included here. If this continues to be a
     # slow function, we can wrap the remaining RP calls and let this function be
-    # inlined, or stick the whole function in a separate thread with
-    # loop.run_in_executor().
+    # inlined, or move parts to a separate thread or process with
+    # loop.run_in_executor(). Note, though, that
+    #   * The rp.Session needs to be created in the root thread to be able to correctly
+    #     manage signal handlers and subprocesses, and
+    #   * We need to be able to schedule RP Task callbacks in the same process as the
+    #     asyncio event loop in order to handle Futures for RP tasks.
+    # See https://github.com/SCALE-MS/randowtal/issues/2
 
     # TODO: RP triggers SIGINT in various failure modes.
     #  We should use loop.add_signal_handler() to convert to an exception
-    #  that we can raise in an appropriate task.
+    #  that we can raise in an appropriate task. However, we should make sure that we
+    #  account for the signal handling that RP expects to be able to do.
+    #  See https://github.com/SCALE-MS/randowtal/issues/1
     # Note that PilotDescription can use `'exit_on_error': False` to suppress the SIGINT,
-    # but we have not explored the consequences of doing so.
+    # but we have not fully explored the consequences of doing so.
 
     try:
         #
@@ -502,7 +536,6 @@ def _connect_rp(config: Configuration) -> Runtime:
         #                 scalems_spec
         #             ]}})
 
-        # Question: when should we remove the pilot from the task manager?
         task_manager.add_pilots(pilot)
         logger.debug('Added Pilot {} to task manager {}.'.format(
             pilot.uid,
@@ -531,7 +564,7 @@ def _connect_rp(config: Configuration) -> Runtime:
         except Exception as e:
             raise DispatchError('Could not determine remote RP version.') from e
         # TODO: #100 Improve compatibility checking.
-        if remote_rp_version < packaging.version.parse('1.6.0'):
+        if remote_rp_version < packaging.version.parse(rp.version):
             raise DispatchError(f'Incompatible radical.pilot version in execution '
                                 f'environment: {str(remote_rp_version)}')
 

--- a/src/scalems/radical/scalems_rp_master.py
+++ b/src/scalems/radical/scalems_rp_master.py
@@ -8,67 +8,9 @@ import radical.pilot as rp
 import radical.utils as ru
 from radical.pilot.raptor.request import Request
 
+from scalems.radical.raptor import RequestInputList
+
 logger = logging.getLogger('scalems_rp_master')
-
-_RaptorReturnType = typing.Tuple[typing.Text, typing.Text, typing.SupportsInt]
-"""Raptor worker task return values are interpreted as a tuple (out, err, ret).
-
-The first two elements are cast to output and error strings, respectively.
-
-The third is cast to an integer return code.
-"""
-
-_RaptorWorkData = typing.TypeVar('_RaptorWorkData')
-"""Argument type for a Raptor task implementation.
-
-Constraints on the data type are not yet well-defined.
-Presumably, the object must be "Munch"-able.
-"""
-
-_RequestInput = typing.NewType('_RequestInput', typing.Mapping)
-"""Input argument for a raptor.Request instantiation.
-
-Not yet fully specified, but not to be confused with
-raptor.Request instances.
-
-A dict-like object with at least a *uid* key.
-"""
-
-
-class RaptorWorkCallable(typing.Protocol[_RaptorWorkData]):
-    def __call__(self, data: _RaptorWorkData) -> _RaptorReturnType:
-        ...
-
-
-class RaptorWorkDescription(typing.Protocol[_RaptorWorkData]):
-    """Represent the content of an *arguments* element in a RaptorTaskDescription.
-
-    A dictionary resembling this structure is converted to radical.pilot.raptor.Request
-    by the Master in radical.pilot.raptor.Master.request().
-
-    Attributes:
-        mode (str): Dispatching key for raptor.Worker._dispatch()
-
-    Note that some keys may be added or overwritten during Master._receive_tasks
-    (e.g. *is_task*, *uid*, *task*).
-    """
-    cores: int
-    timeout: typing.SupportsFloat
-    mode: str  # Must map to a mode (RaptorWorkCallable) in the receiving Worker._modes
-    data: _RaptorWorkData  # Munch-able object to be passed to Worker._modes[*mode*](*data*)
-
-
-class _RaptorTaskDescription(typing.Protocol):
-    """Note the distinctions of a TaskDescription to processed by a raptor.Master.
-
-
-    The single element of *arguments* is a JSON-encoded object that will be
-    deserialized (RaptorWorkDescription) as the prototype for the dictionary used to instantiate the Request.
-    """
-    uid: str  # Unique identifier for the Task across the Session.
-    executable: typing.ClassVar[str] = 'scalems'  # Unused by Raptor tasks.
-    scheduler: str  # The UID of the raptor.Master scheduler task.
-    arguments: typing.Sequence[str]  # Processed by raptor.Master._receive_tasks
 
 
 class ScaleMSMaster(rp.raptor.Master):
@@ -80,32 +22,32 @@ class ScaleMSMaster(rp.raptor.Master):
 
     def result_cb(self, requests: typing.Sequence[Request]):
         for r in requests:
-            r['task']['stdout'] = r.result['out']
-
             logger.info('result_cb %s: %s [%s]' % (r.uid, r.state, r.result))
 
-    # What is the relationship between the create_work_items() hook and request()?
-    # def create_work_items(self):
-    #     super().create_work_items()
+    def request_cb(self, requests: RequestInputList) -> RequestInputList:
+        """Allows all incoming requests to be processed by the Master.
 
-    def request(self, reqs: typing.Sequence[_RequestInput]) -> list:
-        # 'arguments' (element 0) gets wrapped in a Request at the Master by _receive_tasks,
-        # then the list of requests is passed to Master.request(), which is presumably
-        # an extension point for derived Master implementations. The base class method
-        # converts requests to dictionaries and adds them to a request queue, from which they are
-        # picked up by the Worker in _request_cb. Then picked up in forked interpreter
-        # by Worker._dispatch, which checks the *mode* of the Request and dispatches
-        # according to native or registered mode implementations. (e.g. 'call' (native) or 'scalems')
+        Request is a dictionary deserialized from Task.description.arguments[0],
+        plus three additional keys.
 
-        for req in reqs:
-            logger.info(f'Received request: {repr(req)}')
-        # TODO: This seems like the place to insert special processing for, say, non-Worker tasks or control signals.
-        return super().request(reqs)
+        Note that Tasks may not be processed in the same order in which they are submitted
+        by the client.
 
-    # def _receive_tasks(self, tasks: typing.Sequence[dict]):
-    #     # The 'arguments' key of each element in *tasks* is a JSON-encoded object
-    #     # with the "work" schema: mode, cores, timeout, and data keys.
-    #     super()._receive_tasks(tasks)
+        If overridden, request_cb() must return a list (presumably, the same as the list
+        of the requests that should be processed normally after the callback). This allows
+        subclasses of rp.raptor.Master to add or remove requests before they become Tasks.
+        The returned list is submitted with self.request() by the base class after the
+        callback returns.
+
+        A Master may call self.request() to self-submit items (e.g. instead of or in
+        addition to manipulating the returned list in request_cb()).
+
+        It is the developer's responsibility to choose unique task IDs (uid) when crafting
+        items for Master.request().
+        """
+        # for req_input in requests:
+        #     request = Request(req=req_input)
+        return requests
 
 
 def main():

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -138,7 +138,8 @@ async def test_exec_rp(pilot_description, rp_venv, cleandir):
             cmd2 = scalems.executable(('/bin/echo', 'hello', 'world'))
             # TODO: Clarify whether/how result() method should work in this scope.
             # TODO: Make scalems.wait(cmd) work as expected in this scope.
-        assert cmd1.done() and cmd2.done()
+        assert cmd1.done()
+        assert cmd2.done()
         logger.debug(cmd1.result())
         logger.debug(cmd2.result())
 


### PR DESCRIPTION
Use the RP callback exclusively for determining Task completion, but include some notes and logs regarding inspection of RP Task state.

Fixes #163 