### PR TITLE
Sms165 workdir

### DIFF
--- a/src/scalems/context/__init__.py
+++ b/src/scalems/context/__init__.py
@@ -1,7 +1,7 @@
 """Execution environment context management.
 """
 
-__all__ = ['scoped_chdir']
+__all__ = ['initialize_datastore', 'scoped_chdir', 'ContextError', 'StaleFileStore']
 
 import contextlib
 import logging
@@ -10,6 +10,10 @@ import pathlib
 import threading
 import typing
 import warnings
+
+from ._datastore import ContextError
+from ._datastore import initialize_datastore
+from ._datastore import StaleFileStore
 
 logger = logging.getLogger(__name__)
 logger.debug('Importing {}'.format(__name__))

--- a/src/scalems/context/_datastore.py
+++ b/src/scalems/context/_datastore.py
@@ -13,7 +13,7 @@ and we should not rely on it. Also, note the sequence with which module variable
 class definitions are released during shutdown.
 
 TODO: Make FileStore look more like a File interface, with open and close and context
-    manager support, and provide boolean status properties. Let get_context() return the
+    manager support, and provide boolean status properties. Let initialize_context() return the
     currently in-scope FileStore.
 """
 
@@ -21,7 +21,7 @@ __all__ = [
     'ContextError',
     'StaleFileStore',
     'finalize_context',
-    'get_context',
+    'initialize_context',
 ]
 
 import dataclasses
@@ -114,7 +114,7 @@ class FileStore:
                         else:
                             assert metadata_dict['instance'] == instance_id
                             w = scalems.exceptions.ProtocolWarning(
-                                'Inappropriate `get_context()` call. This process is '
+                                'Inappropriate `initialize_context()` call. This process is '
                                 f'already managing {metadata_file}'
                             )
                             warnings.warn(w)
@@ -135,10 +135,10 @@ class FileStore:
                 'Could not acquire ownership of working directory {}'.format(dir)) from e
 
 
-def get_context() -> FileStore:
+def initialize_context() -> FileStore:
     """Get a reference to an API Context instance.
 
-    If get_context() succeeds, the caller is responsible for calling `finalize_context()`
+    If initialize_context() succeeds, the caller is responsible for calling `finalize_context()`
     before the interpreter exits.
 
     Raises:
@@ -151,10 +151,10 @@ def get_context() -> FileStore:
 def finalize_context():
     """Mark the local Context data store as inactive.
 
-    Finalize the state of the file-backed Context. Allow future get_context()
+    Finalize the state of the file-backed Context. Allow future initialize_context()
     calls to succeed whether coming from this process or another.
 
-    Must be called at some point after a get_context() call succeeds in order
+    Must be called at some point after a initialize_context() call succeeds in order
     to clean up local state and allow other processes to use the data store.
     """
     # A Python `with` block (the context manager protocol) is the most appropriate way to enforce

--- a/tests/test_context_datastore.py
+++ b/tests/test_context_datastore.py
@@ -13,37 +13,37 @@ import scalems.exceptions
 def test_normal_lifecycle(tmp_path):
     """Test normal Context data store life cycle / state machine.
 
-    initialize_context() should succeed when called in a clean directory or when
+    initialize_datastore() should succeed when called in a clean directory or when
     the current process already owns the data store.
     """
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.initialize_context()
-        scalems.context._datastore.finalize_context()
+        datastore = scalems.context._datastore.initialize_datastore()
+        scalems.context._datastore.finalize_datastore(datastore)
 
-        scalems.context._datastore.initialize_context()
-        # Multiple calls to initialize_context() currently succeed as long as they are from
+        datastore = scalems.context._datastore.initialize_datastore()
+        # Multiple calls to initialize_datastore() currently succeed as long as they are from
         # the process ID and not concurrent.
         with pytest.warns(scalems.exceptions.ProtocolWarning):
-            scalems.context._datastore.initialize_context()
+            scalems.context._datastore.initialize_datastore()
 
-        scalems.context._datastore.finalize_context()
-        # finalize_context() must be called exactly once for a data store that has been
+        scalems.context._datastore.finalize_datastore(datastore)
+        # finalize_datastore() must be called exactly once for a data store that has been
         # opened.
         with pytest.raises(scalems.context._datastore.StaleFileStore):
-            scalems.context._datastore.finalize_context()
+            scalems.context._datastore.finalize_datastore(datastore)
 
     # Confirm some assumptions about implementation details.
     filepath = tmp_path / scalems.context._datastore._context_metadata_file
     with _context.scoped_chdir(tmp_path):
-        context = scalems.context._datastore.initialize_context()
-        assert context.instance == os.getpid()
-        assert context.path == filepath
+        datastore = scalems.context._datastore.initialize_datastore()
+        assert datastore.instance == os.getpid()
+        assert datastore.path == filepath
         with pytest.raises(AttributeError):
-            context.log = list()
-        context.log.append('Testing')
+            datastore.log = list()
+        datastore.log.append('Testing')
         with pytest.raises(AttributeError):
-            context.foo = 1
-        scalems.context._datastore.finalize_context()
+            datastore.foo = 1
+        scalems.context._datastore.finalize_datastore(datastore)
     with open(filepath, 'r') as fh:
         metadata: dict = json.load(fh)
         # A finalized record should not have an owning *instance*.
@@ -51,9 +51,9 @@ def test_normal_lifecycle(tmp_path):
 
 
 def test_nonfinalized(tmp_path):
-    """Failure to call finalize_context() should have well-defined behavior."""
+    """Failure to call finalize_datastore() should have well-defined behavior."""
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.initialize_context()
+        scalems.context._datastore.initialize_datastore()
         # In the future, more sophisticated tests might check that Singleton behavior or scoping
         # protections aren't violated.
         # Right now, we have to manipulate the filesystem with knowledge of the implementation
@@ -61,13 +61,13 @@ def test_nonfinalized(tmp_path):
         with open(scalems.context._datastore._context_metadata_file, 'w') as fp:
             json.dump({'instance': 0}, fp)
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.initialize_context()
+            scalems.context._datastore.initialize_datastore()
         # We may want to assert constraints on the filesystem state we expect to encounter
         # even when a lock is left unexpectedly, but initially all we know is that a
         # dangling lock may result from an unclean process termination.
         scalems.context._lock._lock_directory()
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.initialize_context()
+            scalems.context._datastore.initialize_datastore()
         scalems.context._lock._unlock_directory()
 
 
@@ -75,23 +75,23 @@ def test_contention(tmp_path):
     """If two processes try to use the same data store, we should be able to
     detect and prevent it."""
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.initialize_context()
+        datastore = scalems.context._datastore.initialize_datastore()
         scalems.context._lock._lock_directory()
         with pytest.raises(scalems.context._lock.LockException):
-            scalems.context._datastore.finalize_context()
+            scalems.context._datastore.finalize_datastore(datastore)
         scalems.context._lock._unlock_directory()
-        scalems.context._datastore.finalize_context()
+        scalems.context._datastore.finalize_datastore(datastore)
 
         expected_instance = os.getpid()
         unexpected_instance = expected_instance + 1
         with open(scalems.context._datastore._context_metadata_file, 'w') as fp:
             json.dump({'instance': unexpected_instance}, fp)
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.initialize_context()
+            scalems.context._datastore.initialize_datastore()
 
         scalems.context._lock._lock_directory()
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.initialize_context()
+            scalems.context._datastore.initialize_datastore()
         scalems.context._lock._unlock_directory()
 
 
@@ -100,12 +100,12 @@ def test_recovery(tmp_path):
 
     # Follow the lifecycle of a workflow session.
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.initialize_context()
+        datastore = scalems.context._datastore.initialize_datastore()
         with open(tmp_path / scalems.context._datastore._context_metadata_file,
                   'r') as fh:
             metadata: dict = json.load(fh)
             assert 'instance' in metadata
-        scalems.context._datastore.finalize_context()
+        scalems.context._datastore.finalize_datastore(datastore)
         with open(tmp_path / scalems.context._datastore._context_metadata_file,
                   'r') as fh:
             metadata: dict = json.load(fh)
@@ -113,12 +113,12 @@ def test_recovery(tmp_path):
 
     # Open a new session to continue managing the previous workflow data.
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.initialize_context()
+        datastore = scalems.context._datastore.initialize_datastore()
         with open(tmp_path / scalems.context._datastore._context_metadata_file,
                   'r') as fh:
             metadata: dict = json.load(fh)
             assert 'instance' in metadata
-        scalems.context._datastore.finalize_context()
+        scalems.context._datastore.finalize_datastore(datastore)
         with open(tmp_path / scalems.context._datastore._context_metadata_file,
                   'r') as fh:
             metadata: dict = json.load(fh)

--- a/tests/test_context_datastore.py
+++ b/tests/test_context_datastore.py
@@ -13,18 +13,18 @@ import scalems.exceptions
 def test_normal_lifecycle(tmp_path):
     """Test normal Context data store life cycle / state machine.
 
-    get_context() should succeed when called in a clean directory or when
+    initialize_context() should succeed when called in a clean directory or when
     the current process already owns the data store.
     """
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.get_context()
+        scalems.context._datastore.initialize_context()
         scalems.context._datastore.finalize_context()
 
-        scalems.context._datastore.get_context()
-        # Multiple calls to get_context() currently succeed as long as they are from
+        scalems.context._datastore.initialize_context()
+        # Multiple calls to initialize_context() currently succeed as long as they are from
         # the process ID and not concurrent.
         with pytest.warns(scalems.exceptions.ProtocolWarning):
-            scalems.context._datastore.get_context()
+            scalems.context._datastore.initialize_context()
 
         scalems.context._datastore.finalize_context()
         # finalize_context() must be called exactly once for a data store that has been
@@ -35,7 +35,7 @@ def test_normal_lifecycle(tmp_path):
     # Confirm some assumptions about implementation details.
     filepath = tmp_path / scalems.context._datastore._context_metadata_file
     with _context.scoped_chdir(tmp_path):
-        context = scalems.context._datastore.get_context()
+        context = scalems.context._datastore.initialize_context()
         assert context.instance == os.getpid()
         assert context.path == filepath
         with pytest.raises(AttributeError):
@@ -53,7 +53,7 @@ def test_normal_lifecycle(tmp_path):
 def test_nonfinalized(tmp_path):
     """Failure to call finalize_context() should have well-defined behavior."""
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.get_context()
+        scalems.context._datastore.initialize_context()
         # In the future, more sophisticated tests might check that Singleton behavior or scoping
         # protections aren't violated.
         # Right now, we have to manipulate the filesystem with knowledge of the implementation
@@ -61,13 +61,13 @@ def test_nonfinalized(tmp_path):
         with open(scalems.context._datastore._context_metadata_file, 'w') as fp:
             json.dump({'instance': 0}, fp)
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.get_context()
+            scalems.context._datastore.initialize_context()
         # We may want to assert constraints on the filesystem state we expect to encounter
         # even when a lock is left unexpectedly, but initially all we know is that a
         # dangling lock may result from an unclean process termination.
         scalems.context._lock._lock_directory()
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.get_context()
+            scalems.context._datastore.initialize_context()
         scalems.context._lock._unlock_directory()
 
 
@@ -75,7 +75,7 @@ def test_contention(tmp_path):
     """If two processes try to use the same data store, we should be able to
     detect and prevent it."""
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.get_context()
+        scalems.context._datastore.initialize_context()
         scalems.context._lock._lock_directory()
         with pytest.raises(scalems.context._lock.LockException):
             scalems.context._datastore.finalize_context()
@@ -87,11 +87,11 @@ def test_contention(tmp_path):
         with open(scalems.context._datastore._context_metadata_file, 'w') as fp:
             json.dump({'instance': unexpected_instance}, fp)
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.get_context()
+            scalems.context._datastore.initialize_context()
 
         scalems.context._lock._lock_directory()
         with pytest.raises(scalems.context._datastore.ContextError):
-            scalems.context._datastore.get_context()
+            scalems.context._datastore.initialize_context()
         scalems.context._lock._unlock_directory()
 
 
@@ -100,7 +100,7 @@ def test_recovery(tmp_path):
 
     # Follow the lifecycle of a workflow session.
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.get_context()
+        scalems.context._datastore.initialize_context()
         with open(tmp_path / scalems.context._datastore._context_metadata_file,
                   'r') as fh:
             metadata: dict = json.load(fh)
@@ -113,7 +113,7 @@ def test_recovery(tmp_path):
 
     # Open a new session to continue managing the previous workflow data.
     with _context.scoped_chdir(tmp_path):
-        scalems.context._datastore.get_context()
+        scalems.context._datastore.initialize_context()
         with open(tmp_path / scalems.context._datastore._context_metadata_file,
                   'r') as fh:
             metadata: dict = json.load(fh)


### PR DESCRIPTION
We will use FileStore as the first basic record of non-volatile workflow state.

It is non-volatile by virtue of its file-backed data store. It needs improvement, but it is good enough for now.

We can now proceed with adding tracked assets to the managed workflow, such as files that can be staged back and forth to remote workflow managers (e.g. scalems.radical).