### PR TITLE
Async runtime startup

### DIFF
--- a/src/scalems/local/__init__.py
+++ b/src/scalems/local/__init__.py
@@ -242,9 +242,11 @@ class LocalExecutor(_execution.RuntimeManager):
     def updater(self) -> WorkflowUpdater:
         return WorkflowUpdater(runtime=self)
 
-    def runtime_startup(self, runner_started: asyncio.Event) -> asyncio.Task:
+    async def runtime_startup(self) -> asyncio.Task:
+        runner_started = asyncio.Event()
         runner_task = asyncio.create_task(
             _execution.manage_execution(
                 executor=self,
                 processing_state=runner_started))
+        await runner_started.wait()
         return runner_task

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -28,6 +28,13 @@ See Also:
     https://github.com/SCALE-MS/scale-ms/issues/55
 
 """
+
+__all__ = (
+    'parser',
+    'Configuration',
+    'Runtime',
+)
+
 import argparse
 import asyncio
 import contextvars
@@ -364,7 +371,7 @@ def _get_scheduler(name: str,
     return scheduler
 
 
-def _connect_rp(config: Configuration) -> Runtime:
+async def _connect_rp(config: Configuration) -> Runtime:
     """Establish the RP Session.
 
     Acquire a maximally re-usable set of RP resources. The scope established by


### PR DESCRIPTION
Make RuntimeManager.runtime_startup() asynchronous.

Simplifies the interface a bit by allowing us to internalize the check 
for the asyncio.Event that we watch. Callers `await` `runtime_startup()`
instead. Also allows implementers of `runtime_startup` to use asyncio 
internally.

Simplifies the changes associated with some works in progress.

Includes some additional linting.
