### PR TITLE
fix prepare_env signature in tests

### DIFF
--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -110,6 +110,8 @@ async def test_exec_rp(pilot_description, rp_venv, cleandir):
     """
     import radical.pilot as rp
 
+    time.sleep(120)
+
     # Hopefully, this requirement is temporary.
     if rp_venv is None:
         pytest.skip('This test requires a user-provided static RP venv.')

--- a/tests/test_rp_venv.py
+++ b/tests/test_rp_venv.py
@@ -85,11 +85,10 @@ def test_prepare_venv(rp_task_manager, sdist):
 
     tmgr = rp_task_manager
 
-    pilot.prepare_env({
-        'scalems_env': {
-            'type': 'virtualenv',
-            'version': '3.8',
-            'setup': list(sdist_session_paths.values())}})
+    pilot.prepare_env(env_name='scalems_env',
+                      env_spec={'type': 'virtualenv',
+                                'version': '3.8',
+                                'setup': list(sdist_session_paths.values())})
 
     td = rp.TaskDescription({'executable': 'python3',
                              'arguments': ['-c',


### PR DESCRIPTION
This catches up with a change in RP's `project/scalems` branch.