### PR TITLE
Minor version handling improvements.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ author_email = info@scalems.org
 
 [options]
 python_requires = >=3.8
+; Note that we also hard code some Python version checking in setup.py.
 zip_safe = True
 packages = find:
 package_dir =

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,17 @@ import sys
 
 from setuptools import setup
 
+# If the Python version is too low, developers will get a strange error when versioneer
+# tries to import scalems._version since scalems/__init__.py imports some submodules
+# with dependencies on recently-introduced standard library modules.
+_supported = True
+if sys.version_info.major < 3:
+    _supported = False
+if sys.version_info.major == 3 and sys.version_info.minor < 8:
+    _supported = False
+if not _supported:
+    raise RuntimeError('scalems requires Python 3.8 or higher.')
+
 # The versioneer.py is in the same directory as the setup.py
 sys.path.append(os.path.dirname(__file__))
 import versioneer

--- a/src/scalems/utility.py
+++ b/src/scalems/utility.py
@@ -21,11 +21,7 @@ from typing import Protocol
 
 from scalems import exceptions as _exceptions
 from . import get_scope
-from ._version import get_versions
 from .workflow import WorkflowManager
-
-_scalems_version = get_versions()['version']
-del get_versions
 
 logger = logging.getLogger(__name__)
 logger.debug('Importing {}'.format(__name__))
@@ -48,6 +44,8 @@ def parser(add_help=False):
     See Also:
          https://docs.python.org/3/library/argparse.html#parents
     """
+    from . import __version__ as _scalems_version
+
     _parser = argparse.ArgumentParser(add_help=add_help)
 
     _parser.add_argument(


### PR DESCRIPTION
Add a Python version check to `setup.py`:
Try to provide more helpful errors when attempting `pip install .`
from an unsupported Python version.

Limit the scope of a workaround:
Let `scalems.utility.parser` get `scalems.__version__` after import
(when the function is called) to separate the utilty module
from the `versioneer` details.