### PR TITLE
Minimize dependency on WorkflowManager

### DIFF
--- a/src/scalems/context/_datastore.py
+++ b/src/scalems/context/_datastore.py
@@ -749,7 +749,7 @@ class FileStoreManager:
         # Make sure generator function runs up to the first yield.
         next(self.filestore_generator)
 
-    def filestore(self):
+    def filestore(self) -> typing.Union[None, FileStore]:
         try:
             ref = next(self.filestore_generator)
             return ref()

--- a/src/scalems/local/__init__.py
+++ b/src/scalems/local/__init__.py
@@ -215,7 +215,8 @@ async def _execute_item(task_type: TypeIdentifier,  # noqa: C901
 def executor_factory(manager: _workflow.WorkflowManager, params=None):
     if params is not None:
         raise TypeError('This factory does not accept a Configuration object.')
-    executor = LocalExecutor(source=manager,
+    executor = LocalExecutor(editor_factory=weakref.WeakMethod(manager.edit_item),
+                             datastore=manager.datastore(),
                              loop=manager.loop(),
                              dispatcher_lock=manager._dispatcher_lock)
     return executor
@@ -226,22 +227,17 @@ class LocalExecutor(_execution.RuntimeManager):
     """
 
     def __init__(self,
-                 source: _workflow.WorkflowManager = None,
                  *,
                  editor_factory=None,
                  datastore: FileStore = None,
                  loop: asyncio.AbstractEventLoop,
                  configuration=None,
-                 dispatcher_lock=None,
-                 ):
+                 dispatcher_lock=None):
         """Create a client side execution manager.
 
         Initialization and deinitialization occurs through
         the Python (async) context manager protocol.
         """
-        if source:
-            editor_factory = weakref.WeakMethod(source.edit_item)
-            datastore = source.datastore()
         super().__init__(editor_factory=editor_factory,
                          datastore=datastore,
                          loop=loop,

--- a/src/scalems/radical/__init__.py
+++ b/src/scalems/radical/__init__.py
@@ -690,7 +690,12 @@ class RPDispatchingExecutor(RuntimeManager):
             raise ValueError(
                 'Caller must specify a venv to be activated by the execution agent for '
                 'dispatched tasks.')
-        super().__init__(source,
+
+        if source:
+            editor_factory = weakref.WeakMethod(source.edit_item)
+            datastore = source.datastore()
+        super().__init__(editor_factory=editor_factory,
+                         datastore=datastore,
                          loop=loop,
                          configuration=configuration,
                          dispatcher_lock=dispatcher_lock)

--- a/src/scalems/radical/__init__.py
+++ b/src/scalems/radical/__init__.py
@@ -96,6 +96,7 @@ from .runtime import Configuration
 from .runtime import get_pre_exec
 from .runtime import parser as _runtime_parser
 from .runtime import Runtime
+from ..context import FileStore
 from ..identifiers import TypeIdentifier
 from scalems.utility import make_parser as _make_parser
 
@@ -668,11 +669,14 @@ class RPDispatchingExecutor(RuntimeManager):
     """
 
     def __init__(self,
-                 source: scalems.workflow.WorkflowManager,
+                 source: scalems.workflow.WorkflowManager = None,
                  *,
+                 editor_factory: typing.Callable[[], typing.Callable] = None,
+                 datastore: FileStore = None,
                  loop: asyncio.AbstractEventLoop,
                  configuration: Configuration,
-                 dispatcher_lock=None):
+                 dispatcher_lock=None,
+                 ):
         """Create a client side execution manager.
 
         Initialization and de-initialization occurs through
@@ -729,7 +733,7 @@ class RPDispatchingExecutor(RuntimeManager):
                 and len(self._runtime_configuration.execution_target) > 0:
             configuration_dict[
                 'execution_target'] = self._runtime_configuration.execution_target
-        configuration_dict['datastore'] = self.source_context.datastore()
+        configuration_dict['datastore'] = self.datastore
 
         c = Configuration(**configuration_dict)
 

--- a/src/scalems/radical/__init__.py
+++ b/src/scalems/radical/__init__.py
@@ -145,7 +145,8 @@ def executor_factory(manager: scalems.workflow.WorkflowManager,
         _set_configuration(params)
     params = configuration()
 
-    executor = RPDispatchingExecutor(source=manager,
+    executor = RPDispatchingExecutor(editor_factory=weakref.WeakMethod(manager.edit_item),
+                                     datastore=manager.datastore(),
                                      loop=manager.loop(),
                                      configuration=params,
                                      dispatcher_lock=manager._dispatcher_lock)
@@ -669,14 +670,12 @@ class RPDispatchingExecutor(RuntimeManager):
     """
 
     def __init__(self,
-                 source: scalems.workflow.WorkflowManager = None,
                  *,
                  editor_factory: typing.Callable[[], typing.Callable] = None,
                  datastore: FileStore = None,
                  loop: asyncio.AbstractEventLoop,
                  configuration: Configuration,
-                 dispatcher_lock=None,
-                 ):
+                 dispatcher_lock=None):
         """Create a client side execution manager.
 
         Initialization and de-initialization occurs through
@@ -691,9 +690,6 @@ class RPDispatchingExecutor(RuntimeManager):
                 'Caller must specify a venv to be activated by the execution agent for '
                 'dispatched tasks.')
 
-        if source:
-            editor_factory = weakref.WeakMethod(source.edit_item)
-            datastore = source.datastore()
         super().__init__(editor_factory=editor_factory,
                          datastore=datastore,
                          loop=loop,

--- a/src/scalems/workflow/__init__.py
+++ b/src/scalems/workflow/__init__.py
@@ -315,14 +315,6 @@ class WorkflowManager:
           instance.
 
     TODO:
-        Check that I'm actually toggling something for the context instance to avoid
-        recursive dispatch loops rather than just multiple recursion of self.
-        Maybe keep a reference to the context hierarchy node to use when entering,
-        and let implementations decide whether to allow multiple entrance,
-        provided there is a reasonable way to clean up
-        the correct number of times.
-
-    TODO:
         In addition to adding callbacks to futures, allow subscriptions to workflow
         updates.
         This allows intermediate updates to be propagated and could be a superset of

--- a/src/scalems/workflow/__init__.py
+++ b/src/scalems/workflow/__init__.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import queue as _queue
+import threading
 import typing
 import weakref
 
@@ -1160,15 +1161,9 @@ class Queuer:
     #     # # Otherwise, the only allowed value from the iterator is None.
 
 
-class Scope(typing.NamedTuple):
-    """Backward-linked list (potentially branching) to track nested context.
+_shared_scope_lock = threading.RLock()
 
-    There is not much utility to tracking the parent except for introspection
-    during debugging. The previous state is more appropriately held within the
-    closure of the context manager. This structure may be simplified without warning.
-    """
-    parent: typing.Union[None, WorkflowManager]
-    current: WorkflowManager
+_shared_scope_count = contextvars.ContextVar('_shared_scope_count', default=0)
 
 
 _dispatcher: contextvars.ContextVar = contextvars.ContextVar('_dispatcher')
@@ -1183,110 +1178,100 @@ We allow multiple dispatchers to be active, but each dispatcher must
 4. ensure the Context is destroyed (remove circular references)
 """
 
+
 current_scope: contextvars.ContextVar = contextvars.ContextVar('current_scope')
-"""The active workflow manager
+"""The active workflow manager, if any.
 
 This property is global within the interpreter or a `contextvars.Context`.
 
-Note: Scope indicates the hierarchy of "active" WorkflowManager instances
-(related by dispatching).
-This is separate from WorkflowManager lifetime and ownership.
-WorkflowManagers should track their own activation status and provide logic for
-whether to allow reentrant dispatching.
-
-TODO: Shouldn't the previous "current" be notified or negotiated with? Should we be
- locking something?
-
 Note that it makes no sense to start a dispatching session without concurrency,
-so we can think in terms of a parent context doing contextvars.copy_context().run(...)
-I think we have to make sure not to nest scopes without a combination of copy_context
-and context managers, so we don't need to track the parent scope. We should also be
-able to use weakrefs.
+so we can think in terms of a parent context doing contextvars.copy_context().run(...),
+but the parent must set the current_scope correctly in the new Context.
 """
 
 
-def get_scope() -> WorkflowManager:
+def get_scope():
     """Get a reference to the manager of the current workflow scope."""
-    # TODO: Redocument and adjust semantics.
-    # The contextvars and get_scope should only be used in conjunction with
-    # a workflow_scope() context manager that is explicitly not thread-safe, but
-    # which can employ some checks for non-multi-threading access assumptions.
     # get_scope() is used to determine the default workflow manager when *context*
     # is not provided to scalems object factories, scalems.run(), scalems.wait() and
-    # (non-async) `result()` methods. Default *context* values are a user convenience
-    # and so should only occur in the root thread for the UI / high-level scripting
-    # interface.
+    # (non-async) `result()` methods.
     # Async coroutines can safely use get_scope(), but should not use the
-    # non-async workflow_scope() context manager for nested scopes without wrapping
-    # in a contextvars.run().
-    global current_scope
+    # non-async scope() context manager for nested scopes without wrapping
+    # in a contextvars.run() that locally resets the Context current_scope.
     try:
-        _scope: Scope = current_scope.get()
-        manager = _scope.current
-        logger.debug(f'Scope queried with get_scope() {repr(manager)}')
+        _scope: typing.Union[WorkflowManager, weakref.ReferenceType] = current_scope.get()
+        if isinstance(_scope, weakref.ReferenceType):
+            _scope = _scope()
+        manager: WorkflowManager = _scope
         # This check is in case we use weakref.ref:
         if manager is None:
             raise ProtocolError('Context for current scope seems to have disappeared.')
+        logger.debug(f'Scope queried with get_scope() {repr(manager)}')
     except LookupError:
         logger.debug('Scope was queried, but has not yet been set.')
-        manager = None
+        return None
     return manager
 
 
 @contextlib.contextmanager
-def scope(context):
+def scope(manager):
     """Set the current workflow management within a clear scope.
 
-    Restore the previous workflow management scope on exiting the context manager.
+    Restores the previous workflow management scope on exiting the context manager.
+
+    To allow better tracking of dispatching chains, this context manager does not allow
+    the global workflow management scope to be "stolen". If *manager* is already the
+    current scope, a recursion depth is tracked, and the previous scope is restored
+    only when the last "scope" context manager for *manager* exits. Multiple "scope"
+    context managers are not allowed for different *manager* instances in the same
+    :py:class:`context <contextvars.Context>`.
+
+    Note:
+        Scope indicates the "active" WorkflowManager instance.
+        This is separate from WorkflowManager lifetime and ownership.
+        WorkflowManagers should track their own activation status and provide logic for
+        whether to allow reentrant dispatching.
 
     Within the context managed by *scope*, get_scope() will return *context*.
 
-    Not thread-safe. In general, this context manager should only be used in the
-    root thread.
+    While this context manager should be thread-safe, in general, this context manager
+    should only be used in the root thread where the UI and event loop are running to
+    ensure we can clean up properly.
+    Dispatchers may provide environments in which this context manager can be used in
+    non-root threads, but the Dispatcher needs to curate the contextvars.ContextVars
+    and ensure that the Context is properly cleaned up.
     """
-    parent = get_scope()
-    dispatcher = _dispatcher.get(None)
-    if dispatcher is not None and parent is not dispatcher:
-        raise ProtocolError(
-            'It is unsafe to use concurrent scope() context managers in an asynchronous '
-            'context.')
-    logger.debug('Entering scope of {}'.format(str(context)))
-    current = context
-    token = current_scope.set(
-        Scope(
-            parent=parent,
-            current=current)
-    )
-    if token.var.get().parent is current:
-        logger.warning('Unexpected re-entrance. Workflow is already managed by '
-                       f'{repr(current)}')
-    if token.old_value is not token.MISSING and token.old_value.current != \
-            token.var.get().parent:
-        raise ProtocolError(
-            'Unrecoverable race condition: multiple threads are updating global context '
-            'unsafely.')
-    # Try to confirm that current_scope is not already subject to modification by another
-    #  context manager in a shared asynchronous context.
-    # This nesting has to have LIFO semantics both in and out of coroutines,
-    # and cannot block.
-    # One option would be to refuse to nest if the current scope is not the root scope and
-    # the root scope has an active dispatcher. Note that a dispatcher should use
-    # contextvars.copy_context().run() and set a new root context.
-    # Alternatively, we could try to make sure that no asynchronous yields are allowed
-    # when the current context is a nested scope within a dispatcher context,
-    # but technically this is okay as long as a second scope is not nested within the
-    # first from within a coroutine that might not finish until after the first scope
-    # finishes.
-    try:
-        yield current
-    finally:
-        """Exit context manager without processing exceptions."""
-        logger.debug('Leaving scope of {}'.format(str(context)))
-        # Restore context module state since we are not using contextvars.Context.run()
-        # or equivalent.
-        if token.var.get().parent is not parent or token.var.get().current is not current:
-            raise ProtocolError(
-                'Unexpected re-entrance. Workflow scope changed while in context '
-                f'manager {repr(current)}.')
+    logger.debug(f'Request to enter the scope of {manager}.')
+    with _shared_scope_lock:
+        parent = get_scope()
+        dispatcher = _dispatcher.get(None)
+        # A dispatcher can explicitly allow or disallow nested scopes by setting
+        # current_scope to itself or something else.
+        if parent is None or parent is dispatcher or parent is manager:
+            if parent is not manager:
+                logger.debug('Entering scope of {}'.format(str(manager)))
+            token = current_scope.set(weakref.ref(manager))
+            _shared_scope_count.set(_shared_scope_count.get() + 1)
         else:
-            token.var.reset(token)
+            assert dispatcher is not None
+            raise ProtocolError(
+                f'Cannot nest {manager} scope in {parent} scope while dispatching under {dispatcher}.')
+        try:
+            yield manager
+        finally:
+            _shared_scope_count.set(_shared_scope_count.get() - 1)
+            if _shared_scope_count.get() == 0:
+                logger.debug('Leaving scope of {}'.format(str(manager)))
+                token.var.reset(token)
+    # If we need to have multiple nested scopes across different threads, we can
+    # hold the lock only for __enter__ and __exit__, but we will need to get the
+    # lock object from a ContextVar or from the dispatcher. Then the above `try`
+    # block would be moved up a level and would look something like the following.
+    # try:
+    #     yield manager
+    # finally:
+    #     with _shared_scope_lock:
+    #         _shared_scope_count.set(_shared_scope_count.get() - 1)
+    #         if _shared_scope_count.get() == 0:
+    #             logger.debug('Leaving scope of {}'.format(str(manager)))
+    #             token.var.reset(token)

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -164,25 +164,6 @@ async def test_exec_rp(pilot_description, rp_venv, cleandir):
                 line = fh.readline()
                 assert line.rstrip() == 'hello world'
 
-    import gc
-    # gc.set_debug(gc.DEBUG_LEAK)
-
-    # `manager = None` Does not finalize the FileStoreManager because there are
-    # references to the WorkflowManager or FileStoreManager in several frames still
-    # floating around. Consider only passing WorkflowManager by weakref, etc.
-    # assert sys.getrefcount(manager) == 4
-    # At this point there are 4 references to `manager`, though 1 would be removed
-    # through garbage collection.
-    gc.collect()
-    # assert sys.getrefcount(manager) == 3
-    # TODO: Get ref count for manager down to 1 without garbage collection and confirm
-    #  that the following results in finalization.
-    del manager
-    # logger.debug(gc.garbage)
-    gc.collect()  # Forces the FileStoreManager generator to be closed.
-    # Rather than worry about when gc happens, we could use an alternate protocol,
-    # or just allow a WorkflowManager.close() method.
-
     # Test active context scoping.
     assert scalems.workflow.get_scope() is original_context
     assert not loop.is_closed()


### PR DESCRIPTION
Reduce references (or reference strength) to WorkflowManager instances. Reduce dependencies on the `scalems.workflow` module.

Gets us closer to decoupling the workflow, and execution modules.

Also improves the ability to automatically flush the FileStore promptly.
