### PR TITLE
Test prepare_env venv registration.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -393,7 +393,7 @@ jobs:
         pip freeze
         radical-stack
     - name: Test local.github with pytest
-      timeout-minutes: 15
+      timeout-minutes: 20
       env:
         RADICAL_PILOT_DBURL: mongodb://root:password@localhost:${{ job.services.mongodb.ports[27017] }}/admin
       run: |
@@ -412,7 +412,8 @@ jobs:
             --cov=scalems --cov-report=xml:coverage-$file.xml \
             -rA -l --full-trace --log-cli-level=debug \
             tests/$file \
-            --rp-venv $HOME/testenv --rp-resource=local.github --rp-access=ssh
+            --rp-venv $HOME/testenv --rp-resource=local.github --rp-access=ssh \
+            --experimental
         done
     - name: Command line tests
       timeout-minutes: 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,7 +219,7 @@ jobs:
   rp_ssh:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     services:
       mongodb:
         image: mongo
@@ -275,7 +275,7 @@ jobs:
         pip freeze
         radical-stack
     - name: Test local.github with pytest
-      timeout-minutes: 15
+      timeout-minutes: 20
       env:
         RADICAL_PILOT_DBURL: mongodb://root:password@localhost:${{ job.services.mongodb.ports[27017] }}/admin
       run: |
@@ -331,7 +331,7 @@ jobs:
   rp_ssh_head:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     services:
       mongodb:
         image: mongo

--- a/docs/invocation.rst
+++ b/docs/invocation.rst
@@ -144,7 +144,7 @@ target venv, as well as for satisfying any other workflow software dependencies.
     the agent environment will be updated to the client-side versions automatically.
     When the task uses a separate environment,
     the user must separately update the environment named by
-    :option:`--venv <scalems.radical --venv>`.
+    :option:`--venv <scalems.radical venv>`.
 
     Ultimately, `scalems.radical` will provide more automatic assistance for this.
     (See https://github.com/SCALE-MS/scale-ms/issues/141). In the mean time,
@@ -154,12 +154,9 @@ target venv, as well as for satisfying any other workflow software dependencies.
 To reproduce the environment seen by your Tasks when interactively using the
 static venv, be sure to *activate* the venv.
 
-.. Note: the agent venv is not fully hidden in RP 1.14:
-   https://github.com/radical-cybertools/radical.pilot/issues/2609
-
 If you are using a static venv for the Pilot resource,
 you may specify the :ref:`Pilot venv <venvs>` path to
-:option:`--venv <scalems.radical --venv>`.
+:option:`--venv <scalems.radical venv>`.
 You still must make sure that the venv provides `scalems` and the other
 workflow software dependencies.
 If you are using a dynamically maintained Pilot venv (``create`` or ``update``),
@@ -172,6 +169,9 @@ then you should use a separate venv for your tasks.
 
 named_env
 """""""""
+
+.. note:: `scalems` does not currently use *prepare_env()* or *named_env*.
+    See https://github.com/SCALE-MS/scale-ms/issues/90
 
 `scalems.radical` is migrating towards more dynamic and automated Python
 environment preparation for workflow tasks.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    # Ref https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+    # Ref https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option  # noqa: E501
     if config.getoption("--experimental"):
         # --experimental given in cli: do not skip experimental tests
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,24 @@ def pytest_addoption(parser):
         default='always',
         help='Remove temporary test working directory "always", "never", or on "success".'
     )
+    parser.addoption(
+        "--experimental", action="store_true", default=False, help="run tests for experimental features"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "experimental: mark test as experimental")
+
+
+def pytest_collection_modifyitems(config, items):
+    # Ref https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+    if config.getoption("--experimental"):
+        # --experimental given in cli: do not skip experimental tests
+        return
+    skip_experimental = pytest.mark.skip(reason="need --experimental option to run")
+    for item in items:
+        if "experimental" in item.keywords:
+            item.add_marker(skip_experimental)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/test_rp_venv.py
+++ b/tests/test_rp_venv.py
@@ -191,8 +191,9 @@ def test_prepare_venv(rp_task_manager, sdist, rp_venv):
         assert access == 'ssh'
 
         domain, target = str(pilot.resource).split('.')
-        resource_config = ru.Config(module='radical.pilot.resource',
-                           name=domain)[target]
+        resource_config = ru.Config(
+            module='radical.pilot.resource',
+            name=domain)[target]
         ssh_target = resource_config[access]['job_manager_endpoint']
         result: ParseResult = urlparse(ssh_target)
         assert result.scheme == 'ssh'
@@ -227,9 +228,11 @@ def test_prepare_venv(rp_task_manager, sdist, rp_venv):
     python_version = process.stdout.rstrip()
     logger.debug(f'Requesting Python version {python_version}.')
     pilot.prepare_env(env_name='scalems_env',
-                      env_spec={'type': 'virtualenv',
-                                'version': python_version,
-                                'setup': packages})
+                      env_spec={
+                          'type': 'virtualenv',
+                          'version': python_version,
+                          'setup': packages
+                      })
 
     rp_check_desc = rp.TaskDescription(
         {

--- a/tests/test_rp_venv.py
+++ b/tests/test_rp_venv.py
@@ -4,7 +4,6 @@ import os
 import shlex
 import shutil
 import subprocess
-import sys
 import typing
 from urllib.parse import ParseResult
 from urllib.parse import urlparse
@@ -52,7 +51,7 @@ def test_register_venv(cleandir, rp_task_manager, rp_venv):
     scriptlet = f'test -d {env_path} && rm -rf {env_path} || true '
     scriptlet += f'; {executable} -m venv {env_path} '
     scriptlet += f'; . {env_path}/bin/activate '
-    scriptlet += f'; python -m pip install --upgrade pip setuptools wheel '
+    scriptlet += '; python -m pip install --upgrade pip setuptools wheel '
     scriptlet += f'; pip install radical.pilot=={rp.version}'
     command = [
         'bash',

--- a/tests/test_rp_venv.py
+++ b/tests/test_rp_venv.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+@pytest.mark.experimental
 def test_register_venv(cleandir, rp_task_manager, rp_venv):
     """Use prepare_env() to register an existing venv."""
     import radical.pilot as rp

--- a/tests/test_rp_venv.py
+++ b/tests/test_rp_venv.py
@@ -1,16 +1,104 @@
 """Tests related to RP handling of virtual environments."""
 import logging
 import os
+import platform
+import shlex
+import shutil
+import subprocess
+import sys
 import typing
-import urllib.parse
+from urllib.parse import ParseResult
+from urllib.parse import urlparse
 
 import packaging.version
+import pytest
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def test_prepare_venv(rp_task_manager, sdist):
+def test_register_venv(cleandir, pilot_description):
+    access = pilot_description['access_schema']
+    # Hopefully, this requirement is temporary.
+    if access != 'local':
+        pytest.skip('This test only runs for local tests.')
+
+    import radical.pilot as rp
+
+    pilot_description = {
+        'resource': 'local.localhost',
+        'cores': 4,
+        'gpus': 0,
+        'runtime': 10,
+        'exit_on_error': False
+    }
+    with rp.Session() as session:
+        logger.info(f'Session ID: {session.uid}')
+        pmgr = rp.PilotManager(session=session)
+        pilot = pmgr.submit_pilots(rp.PilotDescription(pilot_description))
+        tmgr = rp.TaskManager(session=session)
+        tmgr.add_pilots(pilot)
+
+        env_name = 'test-env'
+        env_path = '/tmp/test_env'
+
+        process = subprocess.run(
+            args=[
+                sys.executable,
+                '-m', 'venv',
+                env_path
+            ],
+            shell=False
+        )
+        logger.debug(f'stdout: {process.stdout}')
+        logger.error(f'stderr: {process.stderr}')
+        assert process.returncode == 0
+
+        shell = f'. {env_path}/bin/activate; python -m pip install radical.pilot==1.14'
+
+        process = subprocess.run(
+            args=[
+                '/bin/bash', '-c', shell
+            ],
+            shell=False
+        )
+        logger.debug(f'stdout: {process.stdout}')
+        logger.error(f'stderr: {process.stderr}')
+        assert process.returncode == 0
+
+        version = platform.python_version()
+        version = '.'.join(version.split('.')[0:2])
+
+        # Register venv
+        pilot.prepare_env(
+            env_name=env_name,
+            env_spec={
+                'type': 'virtualenv',
+                'path': env_path,
+                'version': version,
+                'setup': []
+            }
+        )
+
+        td = {
+            'executable': 'python',
+            'arguments': ['-c', 'import sys; print(sys.executable)'],
+            'named_env': env_name,
+            'pre_exec': [],
+            'stage_on_error': True,
+            'cpu_processes': 1,
+        }
+
+        task = tmgr.submit_tasks(rp.TaskDescription(td))
+        task.wait(state=[rp.states.AGENT_EXECUTING] + rp.FINAL, timeout=120)
+        logger.info(f'state is {task.state}.')
+        if task.stderr:
+            logger.error(task.stderr)
+        assert task.exit_code == 0
+        assert env_path + '/bin/python' in task.stdout
+
+
+def test_prepare_venv(rp_task_manager, sdist, rp_venv):
     """Bootstrap the scalems package in a RP target environment using pilot.prepare_env.
 
     Note that we cannot wait on the environment preparation directly, but we can define
@@ -52,7 +140,7 @@ def test_prepare_venv(rp_task_manager, sdist):
     for path in sdist_local_paths.values():
         assert os.path.exists(path)
 
-    sandbox_path = urllib.parse.urlparse(pilot.pilot_sandbox).path
+    sandbox_path = urlparse(pilot.pilot_sandbox).path
 
     sdist_session_paths = {name: os.path.join(sandbox_path, sdist_names[name]) for name in sdist_names.keys()}
 
@@ -76,8 +164,64 @@ def test_prepare_venv(rp_task_manager, sdist):
         'wheel']
     packages.extend(sdist_session_paths.values())
 
-    python_version = '3.8'
+    # We test in multiple environments, so we have to check what Python
+    # interpreter is installed in the current target resource.
+    # Note that, at this time, we use a single (user-specified) venv for the
+    # Pilot agent and for the tasks.
+    executable = os.path.join(rp_venv, 'bin', 'python3')
+    scriptlet = 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'
+    access = pilot.description['access_schema']
+    if access == 'local':
+        command = [
+            executable,
+            '-c',
+            scriptlet]
+        process = subprocess.run(
+            args=command,
+            capture_output=True,
+            check=True,
+            text=True
+        )
+    else:
+        # We don't have automated handling for other access methods at this time.
+        assert access == 'ssh'
 
+        domain, target = str(pilot.resource).split('.')
+        resource_config = ru.Config(module='radical.pilot.resource',
+                           name=domain)[target]
+        ssh_target = resource_config[access]['job_manager_endpoint']
+        result: ParseResult = urlparse(ssh_target)
+        assert result.scheme == 'ssh'
+        user = result.username
+        port = result.port
+        host = result.hostname
+
+        ssh = [shutil.which('ssh')]
+        if user:
+            ssh.extend(['-l', user])
+        if port:
+            ssh.extend(['-p', str(port)])
+        ssh.append(host)
+
+        command = [
+            executable,
+            '-c',
+            shlex.quote(scriptlet)]
+
+        logger.debug(f'Executing subprocess {ssh + command}')
+        process = subprocess.run(
+            ssh + command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+            encoding='utf-8')
+        if process.returncode != 0:
+            logger.error('Failed ssh stdout: ' + str(process.stdout))
+            logger.error('Failed ssh stderr: ' + str(process.stderr))
+
+    assert process.returncode == 0
+    python_version = process.stdout.rstrip()
+    logger.debug(f'Requesting Python version {python_version}.')
     pilot.prepare_env(env_name='scalems_env',
                       env_spec={'type': 'virtualenv',
                                 'version': python_version,
@@ -135,7 +279,7 @@ def test_prepare_venv(rp_task_manager, sdist):
         task = tmgr.submit_tasks(td)
         tmgr.wait_tasks()
         assert task.exit_code == 0
-        remote_py_version = task.stdout.rstrip()
         requested_version = packaging.version.parse(python_version)
+        remote_py_version = '.'.join(task.stdout.rstrip().split('.')[0:2])
         remote_py_version = packaging.version.parse(remote_py_version)
         assert requested_version == remote_py_version


### PR DESCRIPTION
Check the resolution of https://github.com/radical-cybertools/radical.pilot/issues/2621

Prepare again to migrate to `prepare_env()` and `named_env` if/when it appears more robust than `pre_exec`.

See also https://github.com/radical-cybertools/radical.pilot/issues/2589
