### PR TITLE
Restore documentation builds on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,20 +5,19 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+  apt_packages:
+    - libopenmpi-dev
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
-# Optionally build your docs in additional formats such as PDF and ePub
-#formats: []
-
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
Update config for readthedocs.org to allow automated documentation builds to work again.

Fixes #210.