### PR TITLE
Apply stronger Python style normalization.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,6 @@ max-line-length = 120
 exclude =
     # Ignore third-party sources.
     _version.py
+    # Ignore examples, for now.
+    examples/
+extend-ignore = E203

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Test Status](https://github.com/SCALE-MS/scale-ms/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/SCALE-MS/scale-ms/actions/workflows/tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/scale-ms/badge/?version=latest)](https://scale-ms.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/SCALE-MS/scale-ms/branch/master/graph/badge.svg)](https://codecov.io/gh/SCALE-MS/scale-ms)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [[DockerHub]](https://hub.docker.com/r/scalems/ci)
 
 NSF Awards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,16 @@ rmprefix = "scalems-"
 
 [tool.versioningit.write]
 file = "src/scalems/_version.py"
+
+[tool.black]
+line-length = 120
+target-version = ['py38', 'py39', 'py310']
+include = '\.pyi?$'
+# 'extend-exclude' excludes files or directories in addition to the defaults
+extend-exclude = '''
+# A regex preceded with ^/ will apply only to files and directories
+# in the root of the project.
+(
+  ^/examples
+)
+'''

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,3 +1,4 @@
+black
 build
 coverage
 flake8

--- a/src/scalems/__init__.py
+++ b/src/scalems/__init__.py
@@ -32,17 +32,17 @@ Invocation:
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-automodule
 __all__ = [
     # core UI
-    'app',
-    'FileReference',
+    "app",
+    "FileReference",
     # tools / commands
-    'executable',
+    "executable",
     # utilities and helpers
-    'get_scope',
+    "get_scope",
     # 'run',
     # 'wait',
-    '__version__',
+    "__version__",
     # core API
-    'ScriptEntryPoint',
+    "ScriptEntryPoint",
 ]
 
 import logging
@@ -55,4 +55,4 @@ from .utility import ScriptEntryPoint
 from .context import FileReference
 
 logger = logging.getLogger(__name__)
-logger.debug('Imported {}'.format(__name__))
+logger.debug("Imported {}".format(__name__))

--- a/src/scalems/_types.py
+++ b/src/scalems/_types.py
@@ -5,10 +5,8 @@ used in multiple modules without tightly coupling those modules.
 """
 import typing
 
-json_base_encodable_types: typing.Tuple[type, ...] = (
-    dict, list, tuple, str, int, float, bool, type(None))
+json_base_encodable_types: typing.Tuple[type, ...] = (dict, list, tuple, str, int, float, bool, type(None))
 
-json_base_decoded_types: typing.Tuple[type, ...] = (
-    dict, list, str, int, float, bool, type(None))
+json_base_decoded_types: typing.Tuple[type, ...] = (dict, list, str, int, float, bool, type(None))
 BaseEncodable = typing.Union[dict, list, tuple, str, int, float, bool, None]
 BaseDecoded = typing.Union[dict, list, str, int, float, bool, None]

--- a/src/scalems/commands.py
+++ b/src/scalems/commands.py
@@ -10,17 +10,17 @@ specification.
 # to be tidy.
 
 __all__ = [
-    'desequence',
-    'extend_sequence',
-    'gather',
-    'logical_and',
-    'logical_not',
-    'map',
-    'reduce',
-    'resequence',
-    'scatter',
-    'subgraph',
-    'while_loop',
+    "desequence",
+    "extend_sequence",
+    "gather",
+    "logical_and",
+    "logical_not",
+    "map",
+    "reduce",
+    "resequence",
+    "scatter",
+    "subgraph",
+    "while_loop",
 ]
 
 from scalems import exceptions

--- a/src/scalems/context/__init__.py
+++ b/src/scalems/context/__init__.py
@@ -2,14 +2,14 @@
 """
 
 __all__ = (
-    'describe_file',
-    'get_file_reference',
-    'scoped_chdir',
-    'ContextError',
-    'StaleFileStore',
-    'FileReference',
-    'FileStore',
-    'FileStoreManager',
+    "describe_file",
+    "get_file_reference",
+    "scoped_chdir",
+    "ContextError",
+    "StaleFileStore",
+    "FileReference",
+    "FileStore",
+    "FileStoreManager",
 )
 
 import contextlib
@@ -29,7 +29,7 @@ from ._datastore import FileStoreManager
 from ._file import FileReference
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 cwd_lock = threading.Lock()
 
@@ -49,13 +49,13 @@ def scoped_chdir(directory: typing.Union[str, bytes, os.PathLike]):
         directory = os.fsdecode(directory)
     path = pathlib.Path(directory)
     if not path.exists() or not path.is_dir():
-        raise ValueError(f'Not a valid directory: {str(directory)}')
+        raise ValueError(f"Not a valid directory: {str(directory)}")
     if cwd_lock.locked():
-        warnings.warn('Another call has already used scoped_chdir. Waiting for lock...')
+        warnings.warn("Another call has already used scoped_chdir. Waiting for lock...")
     with cwd_lock:
         oldpath = os.getcwd()
         os.chdir(path)
-        logger.debug(f'Changed current working directory to {path}')
+        logger.debug(f"Changed current working directory to {path}")
         try:
             yield path
             # If the `with` block using scoped_chdir produces an exception, it will
@@ -63,6 +63,6 @@ def scoped_chdir(directory: typing.Union[str, bytes, os.PathLike]):
             # propagate out of the `with` block, but first we want to restore the
             # original working directory, so we skip `except` but provide a `finally`.
         finally:
-            logger.debug(f'Changing working directory back to {oldpath}')
+            logger.debug(f"Changing working directory back to {oldpath}")
             os.chdir(oldpath)
-    logger.info('scoped_chdir exited.')
+    logger.info("scoped_chdir exited.")

--- a/src/scalems/context/_file.py
+++ b/src/scalems/context/_file.py
@@ -1,6 +1,6 @@
 """Provide an interface for managing filesystem objects in a workflow."""
 
-__all__ = ['FileReference', 'DataLocalizationError']
+__all__ = ["FileReference", "DataLocalizationError"]
 
 import abc
 import pathlib
@@ -57,7 +57,7 @@ class FileReference(typing.Protocol):
         raise NotImplementedError
 
     @abc.abstractmethod
-    async def localize(self, context=None) -> 'FileReference':
+    async def localize(self, context=None) -> "FileReference":
         """Make sure that the referenced file is available locally for a given context.
 
         With no arguments, *localize()* affects the currently active FileStore.

--- a/src/scalems/context/_lock.py
+++ b/src/scalems/context/_lock.py
@@ -1,8 +1,6 @@
 """Provide locking protocol for scalems.context data stores."""
 
-__all__ = ['LockException',
-           'is_locked',
-           'scoped_directory_lock']
+__all__ = ["LockException", "is_locked", "scoped_directory_lock"]
 
 import contextlib
 import logging
@@ -12,9 +10,9 @@ import typing
 import warnings
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
-_lock_directory_name = '.scalems_lock'
+_lock_directory_name = ".scalems_lock"
 """Name to use for lock directories (module constant)"""
 
 
@@ -57,7 +55,7 @@ def _lock_directory(path=None):
         token_path.mkdir()
     except FileExistsError as e:
         # Directory lock already exists.
-        raise LockException('{} already exists'.format(token_path)) from e
+        raise LockException("{} already exists".format(token_path)) from e
     return token_path
 
 
@@ -83,6 +81,7 @@ class _Lock:
     If the caller has not explicitly released the Lock before it is destroyed,
     a warning is issued and the __del__ method attempts to remove the object.
     """
+
     @property
     def name(self):
         """The name of the filesystem object provided when the lock was established."""
@@ -90,7 +89,7 @@ class _Lock:
 
     def __init__(self, filesystem_object=None):
         if not os.path.exists(filesystem_object):
-            raise ValueError('Provided object is not a usable filesystem token.')
+            raise ValueError("Provided object is not a usable filesystem token.")
         self._filesystem_object = filesystem_object
 
     def is_active(self):
@@ -98,7 +97,7 @@ class _Lock:
 
     def release(self):
         if self._filesystem_object is None:
-            raise ValueError('Attempting to release an inactive lock.')
+            raise ValueError("Attempting to release an inactive lock.")
         _Lock._remove(self._filesystem_object)
         self._filesystem_object = None
 
@@ -110,13 +109,11 @@ class _Lock:
         elif os.path.isdir(path):
             os.rmdir(path)
         else:
-            warnings.warn('Cannot remove unknown filesystem object type: {}'.format(path))
+            warnings.warn("Cannot remove unknown filesystem object type: {}".format(path))
 
     def __del__(self):
         if self._filesystem_object is not None:
-            warnings.warn(
-                'Lock object was not explicitly released! '
-                f'Token: {self._filesystem_object}')
+            warnings.warn(f"Lock object was not explicitly released! Token: {self._filesystem_object}")
             obj = self._filesystem_object
             self._filesystem_object = None
             if os.path.exists(obj):
@@ -152,7 +149,7 @@ def scoped_directory_lock(path: typing.Union[str, bytes, os.PathLike] = None):
     try:
         lock = _Lock(token_path)
     except ValueError as e:
-        raise LockException('Could not create lock object.') from e
+        raise LockException("Could not create lock object.") from e
     try:
         yield lock
         # Control returns to the last line of the `try` block if the the `with`
@@ -163,6 +160,6 @@ def scoped_directory_lock(path: typing.Union[str, bytes, os.PathLike] = None):
         # careful about automatically removing non-empty directories on behalf
         # of users.
         if not lock.is_active():
-            warnings.warn(f'Lock object {lock.name} does not exist!')
+            warnings.warn(f"Lock object {lock.name} does not exist!")
         else:
             lock.release()

--- a/src/scalems/exceptions.py
+++ b/src/scalems/exceptions.py
@@ -8,7 +8,7 @@ from exceptions specified in scalems.exceptions.
 import logging as _logging
 
 logger = _logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 
 class ScaleMSError(Exception):

--- a/src/scalems/invocation.py
+++ b/src/scalems/invocation.py
@@ -101,12 +101,12 @@ class _ManagerT(typing.Protocol):
     the Python Data Model for Callable types.
     See https://docs.python.org/3/reference/datamodel.html#the-standard-type-hierarchy.
     """
+
     def __call__(self, loop: asyncio.AbstractEventLoop) -> scalems.workflow.WorkflowManager:
         ...
 
 
-def run(manager_factory: _ManagerT,  # noqa: C901
-        _loop: asyncio.AbstractEventLoop = None):
+def run(manager_factory: _ManagerT, _loop: asyncio.AbstractEventLoop = None):  # noqa: C901
     """Execute boiler plate for scalems entry point scripts.
 
     Provides consistent logic for command line invocation.
@@ -122,14 +122,13 @@ def run(manager_factory: _ManagerT,  # noqa: C901
     """
     safe = _reentrance_guard.acquire(blocking=False)
     if not safe:
-        raise RuntimeError('scalems launcher is not reentrant.')
+        raise RuntimeError("scalems launcher is not reentrant.")
     try:
         module = sys.modules[manager_factory.__module__]
 
-        parser = getattr(module, 'parser', None)
+        parser = getattr(module, "parser", None)
         if parser is None:
-            raise scalems.exceptions.APIError(
-                'Execution manager modules must provide a `parser` module member.')
+            raise scalems.exceptions.APIError("Execution manager modules must provide a `parser` module member.")
 
         # Strip the current __main__ file from argv. Collect arguments for this script
         # and for the called script.
@@ -139,32 +138,34 @@ def run(manager_factory: _ManagerT,  # noqa: C901
             try:
                 # noinspection PyUnresolvedReferences
                 import pydevd_pycharm
-                pydevd_pycharm.settrace('host.docker.internal', port=12345, stdoutToServer=True, stderrToServer=True)
+
+                pydevd_pycharm.settrace("host.docker.internal", port=12345, stdoutToServer=True, stderrToServer=True)
             except ImportError:
                 ...
 
         if not os.path.exists(args.script):
             # TODO: Support REPL (e.g. https://github.com/python/cpython/blob/3.8/Lib/asyncio/__main__.py)
-            raise RuntimeError('Need a script to execute.')
+            raise RuntimeError("Need a script to execute.")
 
         level = args.log_level
         if level is not None:
             import logging
+
             character_stream = logging.StreamHandler()
             # Optional: Set log level.
-            logging.getLogger('scalems').setLevel(level)
+            logging.getLogger("scalems").setLevel(level)
             character_stream.setLevel(level)
             # Optional: create formatter and add to character stream handler
-            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
             character_stream.setFormatter(formatter)
             # add handler to logger
-            logging.getLogger('scalems').addHandler(character_stream)
-        logger = getattr(module, 'logger')
+            logging.getLogger("scalems").addHandler(character_stream)
+        logger = getattr(module, "logger")
 
-        configure_module = getattr(module, 'configuration', None)
+        configure_module = getattr(module, "configuration", None)
         if configure_module is not None:
             config = configure_module(args)
-            logger.debug(f'Configuration: {config}')
+            logger.debug(f"Configuration: {config}")
 
         sys.argv = [args.script] + script_args
 
@@ -198,11 +199,12 @@ def run(manager_factory: _ManagerT,  # noqa: C901
                         if isinstance(ref, scalems.ScriptEntryPoint):
                             if main is not None:
                                 raise scalems.exceptions.DispatchError(
-                                    'Multiple apps in the same script is not (yet?) supported.')
+                                    "Multiple apps in the same script is not (yet?) supported."
+                                )
                             main = ref
                             ref.name = name
                     if main is None:
-                        raise scalems.exceptions.DispatchError('No scalems.app callables found in script.')
+                        raise scalems.exceptions.DispatchError("No scalems.app callables found in script.")
                     # The scalems.run call hierarchy goes through utility.run
                     # to utility._run to AsyncWorkflowManager.run,
                     # which then goes through WorkflowManager.dispatch().
@@ -216,21 +218,21 @@ def run(manager_factory: _ManagerT,  # noqa: C901
                     # For the moment, we can disable the `scalems.run()` mechanism, I think.
                     # cmd = scalems.run(main, context=context)
 
-                    logger.debug('Starting asyncio run()')
+                    logger.debug("Starting asyncio run()")
                     try:
                         run_dispatch(main, manager)
                     except Exception as e:
-                        logger.exception('Unhandled exception in scalems runner calling dispatch(): ' + str(e))
+                        logger.exception("Unhandled exception in scalems runner calling dispatch(): " + str(e))
                         raise e
                     finally:
                         loop.close()
                     assert loop.is_closed()
 
-                    logger.debug('Finished asyncio run()')
+                    logger.debug("Finished asyncio run()")
                 except SystemExit as e:
                     exitcode = e.code
         except Exception as e:
-            print(f'{module} encountered Exception: {repr(e)}')
+            print(f"{module} encountered Exception: {repr(e)}")
             if exitcode == 0:
                 exitcode = 1
         if exitcode != 0:

--- a/src/scalems/local/__init__.py
+++ b/src/scalems/local/__init__.py
@@ -29,7 +29,7 @@ from ..subprocess._subprocess import SubprocessTask
 from scalems.utility import make_parser as _make_parser
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 
 parser = _make_parser(__package__)
@@ -50,16 +50,14 @@ class _ExecutionContext:
 
     def __init__(self, manager: _workflow.WorkflowManager, identifier: bytes):
         if manager is None:
-            raise ProtocolError('Could not acquire reference to WorkflowManager. Stale '
-                                'reference?')
+            raise ProtocolError("Could not acquire reference to WorkflowManager. Stale reference?")
         self.workflow_manager: _workflow.WorkflowManager = manager
         self.identifier: bytes = identifier
         try:
             self.workflow_manager.item(self.identifier)
         except Exception as e:
-            raise InternalError('Unable to access managed item.') from e
-        self._task_directory = pathlib.Path(os.path.join(os.getcwd(),
-                                                         self.identifier.hex()))  #
+            raise InternalError("Unable to access managed item.") from e
+        self._task_directory = pathlib.Path(os.path.join(os.getcwd(), self.identifier.hex()))  #
         # TODO: Find a canonical way to get
         # the workflow directory.
 
@@ -68,7 +66,7 @@ class _ExecutionContext:
         return self._task_directory
 
     def done(self, set_value: bool = None) -> bool:
-        done_token = os.path.join(self.task_directory, 'done')
+        done_token = os.path.join(self.task_directory, "done")
         if set_value is not None:
             if set_value:
                 pathlib.Path(done_token).touch(exist_ok=True)
@@ -85,8 +83,7 @@ class WorkflowUpdater(_execution.AbstractWorkflowUpdater):
         # TODO: Ensemble handling
         item_shape = item.description().shape()
         if len(item_shape) != 1 or item_shape[0] != 1:
-            raise MissingImplementationError(
-                'Executor cannot handle multidimensional tasks yet.')
+            raise MissingImplementationError("Executor cannot handle multidimensional tasks yet.")
 
         task: asyncio.Task = await submit(item=item)
         return task
@@ -103,52 +100,48 @@ async def submit(item: _workflow.Task) -> asyncio.Task:
             id = key.hex()
         else:
             id = str(key)
-        logger.info(f'Skipping task that is already done. ({id})')
+        logger.info(f"Skipping task that is already done. ({id})")
         # TODO: Update local status and results.
     else:
         assert not item.done()
         assert not item.manager().item(key).done()
         task_type: TypeIdentifier = item.description().type()
-        task = asyncio.create_task(_execute_item(task_type=task_type,
-                                                 item=item,
-                                                 execution_context=execution_context))
+        task = asyncio.create_task(_execute_item(task_type=task_type, item=item, execution_context=execution_context))
         return task
 
 
 # TODO: return an execution status object?
-async def _execute_item(task_type: TypeIdentifier,  # noqa: C901
-                        item: _workflow.Task, execution_context: _ExecutionContext):
+async def _execute_item(
+    task_type: TypeIdentifier, item: _workflow.Task, execution_context: _ExecutionContext  # noqa: C901
+):
     # TODO: Automatically resolve resource types.
-    if task_type == TypeIdentifier(('scalems', 'subprocess', 'SubprocessTask')):
+    if task_type == TypeIdentifier(("scalems", "subprocess", "SubprocessTask")):
         task_type = SubprocessTask()
 
         # TODO: Use abstract input factory.
-        logger.debug('Resolving input for {}'.format(str(item)))
+        logger.debug("Resolving input for {}".format(str(item)))
         input_type = task_type.input_type()
         input_record = input_type(**item.input)
-        input_resources = operations.input_resource_scope(context=execution_context,
-                                                          task_input=input_record)
+        input_resources = operations.input_resource_scope(context=execution_context, task_input=input_record)
 
         # We need to provide a scope in which we guarantee the availability of resources,
         # such as temporary files provided for input, or other internally-generated
         # asyncio entities.
         async with input_resources as subprocess_input:
-            logger.debug('Creating coroutine for {}'.format(task_type.__class__.__name__))
+            logger.debug("Creating coroutine for {}".format(task_type.__class__.__name__))
             # TODO: Use abstract task factory.
-            coroutine = operations.subprocessCoroutine(context=execution_context,
-                                                       signature=subprocess_input)
-            logger.debug('Creating asyncio Task for {}'.format(repr(coroutine)))
+            coroutine = operations.subprocessCoroutine(context=execution_context, signature=subprocess_input)
+            logger.debug("Creating asyncio Task for {}".format(repr(coroutine)))
             awaitable = asyncio.create_task(coroutine)
 
             # TODO: Use abstract results handler.
-            logger.debug('Waiting for task to complete.')
+            logger.debug("Waiting for task to complete.")
             result = await awaitable
             subprocess_exception = awaitable.exception()
             if subprocess_exception is not None:
-                logger.exception('subprocess task raised exception {}'.format(str(
-                    subprocess_exception)))
+                logger.exception("subprocess task raised exception {}".format(str(subprocess_exception)))
                 raise subprocess_exception
-            logger.debug('Setting result for {}'.format(str(item)))
+            logger.debug("Setting result for {}".format(str(item)))
             item.set_result(result)
             # TODO: Need rigorous task state machine.
             execution_context.done(item.done())
@@ -167,7 +160,7 @@ async def _execute_item(task_type: TypeIdentifier,  # noqa: C901
             task_dir = execution_context.task_directory
             if not task_dir.exists():
                 task_dir.mkdir()
-            logger.debug(f'Entering {task_dir}')
+            logger.debug(f"Entering {task_dir}")
             # Note: This limits us to one task-per-process.
             # TODO: Use one (or more) subprocesses per task, setting the working
             #  directory.
@@ -180,8 +173,8 @@ async def _execute_item(task_type: TypeIdentifier,  # noqa: C901
                 implementation = None
                 while namespace_end >= 1:
                     try:
-                        module = '.'.join(task_type.scoped_name()[:namespace_end])
-                        logger.debug(f'Looking for importable module: {module}')
+                        module = ".".join(task_type.scoped_name()[:namespace_end])
+                        logger.debug(f"Looking for importable module: {module}")
                         implementation = importlib.import_module(module)
                     except ImportError:
                         implementation = None
@@ -190,15 +183,15 @@ async def _execute_item(task_type: TypeIdentifier,  # noqa: C901
                     # Try the parent namespace?
                     namespace_end -= 1
                 if namespace_end < 1:
-                    raise InternalError('Bad task_type_identifier.')
+                    raise InternalError("Bad task_type_identifier.")
                 logger.debug(f'Looking for "scalems_helper in {module}.')
-                helper = getattr(implementation, 'scalems_helper', None)
+                helper = getattr(implementation, "scalems_helper", None)
                 if not callable(helper):
                     raise MissingImplementationError(
-                        'Executor does not have an implementation for {}'.format(str(
-                            task_type)))
+                        "Executor does not have an implementation for {}".format(str(task_type))
+                    )
                 else:
-                    logger.debug('Helper found. Passing item to helper for execution.')
+                    logger.debug("Helper found. Passing item to helper for execution.")
                     # Note: we need more of a hook for two-way interaction here.
                     try:
                         local_resources = execution_context.workflow_manager
@@ -208,50 +201,52 @@ async def _execute_item(task_type: TypeIdentifier,  # noqa: C901
                         raise e
                     execution_context.done(item.done())
         except Exception as e:
-            logger.exception(f'Badly handled exception: {e}')
+            logger.exception(f"Badly handled exception: {e}")
             raise e
 
 
 def executor_factory(manager: _workflow.WorkflowManager, params=None):
     if params is not None:
-        raise TypeError('This factory does not accept a Configuration object.')
-    executor = LocalExecutor(editor_factory=weakref.WeakMethod(manager.edit_item),
-                             datastore=manager.datastore(),
-                             loop=manager.loop(),
-                             dispatcher_lock=manager._dispatcher_lock)
+        raise TypeError("This factory does not accept a Configuration object.")
+    executor = LocalExecutor(
+        editor_factory=weakref.WeakMethod(manager.edit_item),
+        datastore=manager.datastore(),
+        loop=manager.loop(),
+        dispatcher_lock=manager._dispatcher_lock,
+    )
     return executor
 
 
 class LocalExecutor(_execution.RuntimeManager):
-    """Client side manager for work dispatched locally.
-    """
+    """Client side manager for work dispatched locally."""
 
-    def __init__(self,
-                 *,
-                 editor_factory=None,
-                 datastore: FileStore = None,
-                 loop: asyncio.AbstractEventLoop,
-                 configuration=None,
-                 dispatcher_lock=None):
+    def __init__(
+        self,
+        *,
+        editor_factory=None,
+        datastore: FileStore = None,
+        loop: asyncio.AbstractEventLoop,
+        configuration=None,
+        dispatcher_lock=None,
+    ):
         """Create a client side execution manager.
 
         Initialization and deinitialization occurs through
         the Python (async) context manager protocol.
         """
-        super().__init__(editor_factory=editor_factory,
-                         datastore=datastore,
-                         loop=loop,
-                         configuration=configuration,
-                         dispatcher_lock=dispatcher_lock)
+        super().__init__(
+            editor_factory=editor_factory,
+            datastore=datastore,
+            loop=loop,
+            configuration=configuration,
+            dispatcher_lock=dispatcher_lock,
+        )
 
     def updater(self) -> WorkflowUpdater:
         return WorkflowUpdater(runtime=self)
 
     async def runtime_startup(self) -> asyncio.Task:
         runner_started = asyncio.Event()
-        runner_task = asyncio.create_task(
-            _execution.manage_execution(
-                executor=self,
-                processing_state=runner_started))
+        runner_task = asyncio.create_task(_execution.manage_execution(executor=self, processing_state=runner_started))
         await runner_started.wait()
         return runner_task

--- a/src/scalems/local/__main__.py
+++ b/src/scalems/local/__main__.py
@@ -9,5 +9,5 @@ import sys
 
 import scalems.invocation
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(scalems.invocation.run(scalems.local.workflow_manager))

--- a/src/scalems/local/operations.py
+++ b/src/scalems/local/operations.py
@@ -89,8 +89,8 @@ async def subprocessCoroutine(context: _ExecutionContext, signature: SubprocessI
 
 
 @contextlib.asynccontextmanager
-async def input_resource_scope(
-    context: _ExecutionContext,  # noqa: C901
+async def input_resource_scope(  # noqa: C901
+    context: _ExecutionContext,
     task_input: typing.Union[scalems.subprocess.SubprocessInput, typing.Awaitable[scalems.subprocess.SubprocessInput]],
 ):
     """Manage the actual execution context of the asyncio.subprocess.Process.

--- a/src/scalems/logger.py
+++ b/src/scalems/logger.py
@@ -28,7 +28,7 @@ Refer to the Python :py:mod:`logging` module for information on connecting to an
 logger output.
 """
 
-__all__ = ['logger']
+__all__ = ["logger"]
 
 # Import system facilities
 from logging import DEBUG
@@ -36,7 +36,7 @@ from logging import getLogger
 from logging import NullHandler
 
 # Define `logger` attribute that is used by submodules to create sub-loggers.
-logger = getLogger('scalems')
+logger = getLogger("scalems")
 # By default, prevent scalems logs from propagating to the root logger (and to sys.stderr)
 # if the user does not take action to handle logging.
 logger.addHandler(NullHandler(level=DEBUG))

--- a/src/scalems/radical/__init__.py
+++ b/src/scalems/radical/__init__.py
@@ -34,11 +34,7 @@ See Also:
 # TODO: Consider converting to a namespace package to improve modularity of
 #  implementation.
 
-__all__ = [
-    'configuration',
-    'parser',
-    'workflow_manager'
-]
+__all__ = ["configuration", "parser", "workflow_manager"]
 
 import asyncio
 import functools
@@ -52,7 +48,7 @@ from .runtime import configuration
 from .runtime import parser as _runtime_parser
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 try:
     cache = functools.cache
@@ -82,8 +78,5 @@ def workflow_manager(loop: asyncio.AbstractEventLoop, directory=None):
         before importing the built-in logging module to avoid spurious warnings.
     """
     from .runtime import executor_factory
-    return scalems.workflow.WorkflowManager(
-        loop=loop,
-        executor_factory=executor_factory,
-        directory=directory
-    )
+
+    return scalems.workflow.WorkflowManager(loop=loop, executor_factory=executor_factory, directory=directory)

--- a/src/scalems/radical/__main__.py
+++ b/src/scalems/radical/__main__.py
@@ -11,5 +11,5 @@ import scalems.invocation
 
 # Can we attach to the rp Logger here?
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(scalems.invocation.run(scalems.radical.workflow_manager))

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -126,11 +126,11 @@ See Also:
 from __future__ import annotations
 
 __all__ = (
-    'configuration',
-    'executor_factory',
-    'parser',
-    'Configuration',
-    'Runtime',
+    "configuration",
+    "executor_factory",
+    "parser",
+    "Configuration",
+    "Runtime",
 )
 
 import argparse
@@ -173,12 +173,12 @@ from ..identifiers import EphemeralIdentifier
 from ..identifiers import TypeIdentifier
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 # TODO: Consider scoping for these context variables.
 # Need to review PEP-567 and PEP-568 to consider where and how to scope the Context
 # with respect to the dispatching scope.
-_configuration = contextvars.ContextVar('_configuration')
+_configuration = contextvars.ContextVar("_configuration")
 
 try:
     cache = functools.cache
@@ -189,10 +189,10 @@ except AttributeError:
 
 def _parse_option(arg: str) -> tuple:
     if not isinstance(arg, str):
-        raise InternalError('Bug: This function should only be called with a str.')
-    if arg.count('=') != 1:
+        raise InternalError("Bug: This function should only be called with a str.")
+    if arg.count("=") != 1:
         raise argparse.ArgumentTypeError('Expected a key/value pair delimited by "=".')
-    return tuple(arg.split('='))
+    return tuple(arg.split("="))
 
 
 @cache
@@ -218,33 +218,33 @@ def parser(add_help=False):
     # Ref https://github.com/SCALE-MS/scale-ms/issues/89
     # See also https://github.com/SCALE-MS/scale-ms/issues/90
     # TODO: Set module variables rather than carry around an args namespace?
-    _parser.add_argument('--venv',
-                         metavar='PATH',
-                         type=str,
-                         required=True,
-                         help='Path to the (pre-configured) Python virtual '
-                              'environment with which RP tasks should be executed. '
-                              '(Required. See also https://github.com/SCALE-MS/scale-ms/issues/90)')
-
     _parser.add_argument(
-        '--resource',
+        "--venv",
+        metavar="PATH",
         type=str,
         required=True,
-        help='Specify a `RP resource` for the radical.pilot.PilotDescription. (Required)'
+        help="Path to the (pre-configured) Python virtual "
+        "environment with which RP tasks should be executed. "
+        "(Required. See also https://github.com/SCALE-MS/scale-ms/issues/90)",
     )
 
     _parser.add_argument(
-        '--access',
+        "--resource",
         type=str,
-        help='Explicitly specify the access_schema to use from the RADICAL resource.'
+        required=True,
+        help="Specify a `RP resource` for the radical.pilot.PilotDescription. (Required)",
     )
 
     _parser.add_argument(
-        '--pilot-option',
-        action='append',
+        "--access", type=str, help="Explicitly specify the access_schema to use from the RADICAL resource."
+    )
+
+    _parser.add_argument(
+        "--pilot-option",
+        action="append",
         type=_parse_option,
-        metavar='<key>=<value>',
-        help='Add a key value pair to the `radical.pilot.PilotDescription`.'
+        metavar="<key>=<value>",
+        help="Add a key value pair to the `radical.pilot.PilotDescription`.",
     )
     return _parser
 
@@ -261,11 +261,12 @@ class Configuration:
     .. todo:: Consider merging with module Runtime state container.
 
     """
+
     # Note that the use cases for this dataclass interact with module ContextVars,
     # pending refinement.
     datastore: FileStore = None
     # TODO: Check that the resource is defined.
-    execution_target: str = 'local.localhost'
+    execution_target: str = "local.localhost"
     rp_resource_params: dict = dataclasses.field(default_factory=dict)
     target_venv: str = None
 
@@ -281,6 +282,7 @@ class Runtime:
         :py:attr:`scalems.radical.runtime.RPDispatchingExecutor.runtime`
 
     """
+
     _session: rp.Session
     scheduler: typing.Optional[rp.Task] = None
 
@@ -290,7 +292,7 @@ class Runtime:
 
     def __init__(self, session: rp.Session):
         if not isinstance(session, rp.Session) or session.closed:
-            raise ValueError('*session* must be an active RADICAL Pilot Session.')
+            raise ValueError("*session* must be an active RADICAL Pilot Session.")
         self._session = session
 
     def reset(self, session: rp.Session):
@@ -300,7 +302,7 @@ class Runtime:
         the provided *session*.
         """
         if not isinstance(session, rp.Session) or session.closed:
-            raise ValueError('*session* must be an active RADICAL Pilot Session.')
+            raise ValueError("*session* must be an active RADICAL Pilot Session.")
         self._session.close()
         # Warning: This is not quite right.
         # The attribute values are deferred to the class dict from initialization. The
@@ -328,8 +330,7 @@ class Runtime:
         ...
 
     @typing.overload
-    def pilot_manager(self, pilot_manager: rp.PilotManager) \
-            -> typing.Union[rp.PilotManager, None]:
+    def pilot_manager(self, pilot_manager: rp.PilotManager) -> typing.Union[rp.PilotManager, None]:
         """Set the current pilot manager as provided."""
         ...
 
@@ -338,7 +339,7 @@ class Runtime:
             return self._pilot_manager
         elif isinstance(pilot_manager, rp.PilotManager):
             if not pilot_manager.session.uid == self.session.uid:
-                raise APIError('Cannot accept a PilotManager from a different Session.')
+                raise APIError("Cannot accept a PilotManager from a different Session.")
             self._pilot_manager = pilot_manager
             return pilot_manager
         else:
@@ -347,10 +348,10 @@ class Runtime:
                 pmgr = self.session.get_pilot_managers(pmgr_uids=uid)
                 assert isinstance(pmgr, rp.PilotManager)
             except (AssertionError, KeyError) as e:
-                raise ValueError(f'{uid} does not describe a valid PilotManager') from e
+                raise ValueError(f"{uid} does not describe a valid PilotManager") from e
             except Exception as e:
-                logger.exception('Unhandled RADICAL Pilot exception.', exc_info=e)
-                raise ValueError(f'{uid} does not describe a valid PilotManager') from e
+                logger.exception("Unhandled RADICAL Pilot exception.", exc_info=e)
+                raise ValueError(f"{uid} does not describe a valid PilotManager") from e
             else:
                 return self.pilot_manager(pmgr)
 
@@ -365,8 +366,7 @@ class Runtime:
         ...
 
     @typing.overload
-    def task_manager(self, task_manager: rp.TaskManager) \
-            -> typing.Union[rp.TaskManager, None]:
+    def task_manager(self, task_manager: rp.TaskManager) -> typing.Union[rp.TaskManager, None]:
         """Set the TaskManager from the provided instance."""
         ...
 
@@ -375,7 +375,7 @@ class Runtime:
             return self._task_manager
         elif isinstance(task_manager, rp.TaskManager):
             if not task_manager.session.uid == self.session.uid:
-                raise APIError('Cannot accept a TaskManager from a different Session.')
+                raise APIError("Cannot accept a TaskManager from a different Session.")
             self._task_manager = task_manager
             return task_manager
         else:
@@ -384,10 +384,10 @@ class Runtime:
                 tmgr = self.session.get_task_managers(tmgr_uids=uid)
                 assert isinstance(tmgr, rp.TaskManager)
             except (AssertionError, KeyError) as e:
-                raise ValueError(f'{uid} does not describe a valid TaskManager') from e
+                raise ValueError(f"{uid} does not describe a valid TaskManager") from e
             except Exception as e:
-                logger.exception('Unhandled RADICAL Pilot exception.', exc_info=e)
-                raise ValueError(f'{uid} does not describe a valid TaskManager') from e
+                logger.exception("Unhandled RADICAL Pilot exception.", exc_info=e)
+                raise ValueError(f"{uid} does not describe a valid TaskManager") from e
             else:
                 return self.task_manager(tmgr)
 
@@ -420,17 +420,16 @@ class Runtime:
 
         pmgr = self.pilot_manager()
         if not pmgr:
-            raise APIError('Cannot set Pilot before setting PilotManager.')
+            raise APIError("Cannot set Pilot before setting PilotManager.")
 
         if isinstance(pilot, rp.Pilot):
             session = pilot.session
             if not isinstance(session, rp.Session):
-                raise APIError(f'Pilot {repr(pilot)} does not have a valid Session.')
+                raise APIError(f"Pilot {repr(pilot)} does not have a valid Session.")
             if session.uid != self.session.uid:
-                raise APIError('Cannot accept a Pilot from a different Session.')
+                raise APIError("Cannot accept a Pilot from a different Session.")
             if pilot.pmgr.uid != pmgr.uid:
-                raise APIError('Pilot must be associated with a PilotManager '
-                               'already configured.')
+                raise APIError("Pilot must be associated with a PilotManager already configured.")
             self._pilot = pilot
             return pilot
         else:
@@ -439,19 +438,18 @@ class Runtime:
                 pilot = pmgr.get_pilots(uids=uid)
                 assert isinstance(pilot, rp.Pilot)
             except (AssertionError, KeyError, ValueError) as e:
-                raise ValueError(f'{uid} does not describe a valid Pilot') from e
+                raise ValueError(f"{uid} does not describe a valid Pilot") from e
             except Exception as e:
                 # TODO: Track down the expected rp exception.
-                logger.exception('Unhandled RADICAL Pilot exception.', exc_info=e)
-                raise ValueError(f'{uid} does not describe a valid Pilot') from e
+                logger.exception("Unhandled RADICAL Pilot exception.", exc_info=e)
+                raise ValueError(f"{uid} does not describe a valid Pilot") from e
             else:
                 return self.pilot(pilot)
 
 
-async def _get_scheduler(pre_exec: typing.Iterable[str],
-                         task_manager: rp.TaskManager,
-                         filestore: FileStore,
-                         scalems_env: str):
+async def _get_scheduler(
+    pre_exec: typing.Iterable[str], task_manager: rp.TaskManager, filestore: FileStore, scalems_env: str
+):
     """Establish the radical.pilot.raptor.Master task.
 
     Create a master rp.Task (running the scalems_rp_master script) with the
@@ -481,7 +479,7 @@ async def _get_scheduler(pre_exec: typing.Iterable[str],
     # master task entry point script
     td.executable = master_script()
 
-    logger.debug(f'Using {filestore}.')
+    logger.debug(f"Using {filestore}.")
 
     # scalems_rp_master will write output before it begins handling requests. The
     # script may crash even before it can write anything, but if it does write
@@ -493,8 +491,7 @@ async def _get_scheduler(pre_exec: typing.Iterable[str],
     # _original_callback_duration = asyncio.get_running_loop().slow_callback_duration
     # asyncio.get_running_loop().slow_callback_duration = 0.5
     config_file = await asyncio.create_task(
-        master_input(filestore=filestore, pre_exec=list(pre_exec), worker_venv=scalems_env),
-        name='get-master-input'
+        master_input(filestore=filestore, pre_exec=list(pre_exec), worker_venv=scalems_env), name="get-master-input"
     )
     # asyncio.get_running_loop().slow_callback_duration = _original_callback_duration
 
@@ -504,55 +501,40 @@ async def _get_scheduler(pre_exec: typing.Iterable[str],
     # scope of a rp.Session for RP bookkeeping. Since there is no other interesting
     # information at this time, we can generate a random ID and track it in our metadata.
     master_identity = EphemeralIdentifier()
-    td.uid = 'scalems-rp-master.' + str(master_identity)
+    td.uid = "scalems-rp-master." + str(master_identity)
 
     # TODO(#75): Automate handling of file staging directives for scalems.FileReference
     # e.g. _add_file_dependency(td, config_file)
-    config_file_name = str(td.uid) + '-config.json'
-    td.input_staging = [
-        {
-            'source': config_file.as_uri(),
-            'target': f'{config_file_name}',
-            'action': rp.TRANSFER
-        }
-    ]
+    config_file_name = str(td.uid) + "-config.json"
+    td.input_staging = [{"source": config_file.as_uri(), "target": f"{config_file_name}", "action": rp.TRANSFER}]
     td.arguments = [config_file_name]
 
-    task_metadata = {
-        'uid': td.uid,
-        'task_manager': task_manager.uid
-    }
+    task_metadata = {"uid": td.uid, "task_manager": task_manager.uid}
 
     to_thread = _utility.get_to_thread()
 
-    await asyncio.create_task(
-        to_thread(filestore.add_task, master_identity, **task_metadata),
-        name='add-task'
-    )
+    await asyncio.create_task(to_thread(filestore.add_task, master_identity, **task_metadata), name="add-task")
     # filestore.add_task(master_identity, **task_metadata)
 
-    logger.debug(f'Launching RP raptor scheduling. Submitting {td}.')
+    logger.debug(f"Launching RP raptor scheduling. Submitting {td}.")
 
-    _task = asyncio.create_task(to_thread(task_manager.submit_tasks, td),
-                                name='submit-Master')
+    _task = asyncio.create_task(to_thread(task_manager.submit_tasks, td), name="submit-Master")
     scheduler: rp.Task = await _task
 
     # WARNING: rp.Task.wait() *state* parameter does not handle tuples, but does not
     # check type.
     _task = asyncio.create_task(
-        to_thread(scheduler.wait, state=[rp.states.AGENT_EXECUTING] + rp.FINAL),
-        name='check-Master-started'
+        to_thread(scheduler.wait, state=[rp.states.AGENT_EXECUTING] + rp.FINAL), name="check-Master-started"
     )
     await _task
-    logger.debug(f'Scheduler in state {scheduler.state}.')
+    logger.debug(f"Scheduler in state {scheduler.state}.")
     # TODO: Generalize the exit status checker for the Master task and perform this
     #  this check at the call site.
     if scheduler.state in rp.FINAL:
         if scheduler.stdout or scheduler.stderr:
-            logger.error(f'scheduler.stdout: {scheduler.stdout}')
-            logger.error(f'scheduler.stderr: {scheduler.stderr}')
-        raise DispatchError(
-            f'Master Task unexpectedly reached {scheduler.state} during launch.')
+            logger.error(f"scheduler.stdout: {scheduler.stdout}")
+            logger.error(f"scheduler.stderr: {scheduler.stderr}")
+        raise DispatchError(f"Master Task unexpectedly reached {scheduler.state} during launch.")
     return scheduler
 
 
@@ -568,10 +550,9 @@ def get_pre_exec(conf: Configuration) -> tuple:
 
     """
     if conf.target_venv is None or len(conf.target_venv) == 0:
-        raise ValueError(
-            'Currently, tasks cannot be dispatched without a target venv.')
+        raise ValueError("Currently, tasks cannot be dispatched without a target venv.")
 
-    activate_venv = '. ' + str(os.path.join(conf.target_venv, 'bin', 'activate'))
+    activate_venv = ". " + str(os.path.join(conf.target_venv, "bin", "activate"))
     # Note: RP may specifically expect a `list` and not a `tuple`.
     sequence = (activate_venv,)
     return sequence
@@ -597,8 +578,7 @@ def _set_configuration(*args, **kwargs) -> Configuration:
     # Caller has provided arguments.
     # Not thread-safe
     if _configuration.get(None):
-        raise APIError(f'configuration() cannot accept arguments when {__name__} is '
-                       f'already configured.')
+        raise APIError(f"configuration() cannot accept arguments when {__name__} is already configured.")
     c = Configuration(*args, **kwargs)
     _configuration.set(c)
     return _configuration.get()
@@ -608,8 +588,7 @@ def _set_configuration(*args, **kwargs) -> Configuration:
 def _(config: Configuration) -> Configuration:
     # Not thread-safe
     if _configuration.get(None):
-        raise APIError(f'configuration() cannot accept arguments when {__name__} is '
-                       f'already configured.')
+        raise APIError(f"configuration() cannot accept arguments when {__name__} is already configured.")
     _configuration.set(config)
     return _configuration.get()
 
@@ -617,21 +596,18 @@ def _(config: Configuration) -> Configuration:
 @_set_configuration.register
 def _(namespace: argparse.Namespace) -> Configuration:
     rp_resource_params = {
-        'PilotDescription':
-            {
-                'access_schema': namespace.access,
-                'exit_on_error': False,
-            }
+        "PilotDescription": {
+            "access_schema": namespace.access,
+            "exit_on_error": False,
+        }
     }
     if namespace.pilot_option is not None and len(namespace.pilot_option) > 0:
         user_options = _PilotDescriptionProxy.normalize_values(namespace.pilot_option)
-        rp_resource_params['PilotDescription'].update(user_options)
+        rp_resource_params["PilotDescription"].update(user_options)
         logger.debug(f'Pilot options: {repr(rp_resource_params["PilotDescription"])}')
 
     config = Configuration(
-        execution_target=namespace.resource,
-        target_venv=namespace.venv,
-        rp_resource_params=rp_resource_params
+        execution_target=namespace.resource, target_venv=namespace.venv, rp_resource_params=rp_resource_params
     )
     return _set_configuration(config)
 
@@ -661,12 +637,11 @@ async def new_session():
     # Note: radical.pilot.Session creation causes several deprecation warnings.
     # Ref https://github.com/radical-cybertools/radical.pilot/issues/2185
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore', category=DeprecationWarning)
+        warnings.simplefilter("ignore", category=DeprecationWarning)
         # This would be a good time to `await`, if an event-loop friendly
         # Session creation function becomes available.
         session_args = dict(uid=session_id, cfg=session_config)
-        _task = asyncio.create_task(to_thread(rp.Session, (), **session_args),
-                                    name='create-Session')
+        _task = asyncio.create_task(to_thread(rp.Session, (), **session_args), name="create-Session")
         session = await _task
         runtime = Runtime(session=session)
     return runtime
@@ -683,7 +658,7 @@ def normalize(hint: object, value):
         TypeError: if value could not be normalized according to hint.
 
     """
-    raise MissingImplementationError(f'No dispatcher for {repr(value)} -> {repr(hint)}.')
+    raise MissingImplementationError(f"No dispatcher for {repr(value)} -> {repr(hint)}.")
 
 
 @normalize.register
@@ -694,9 +669,9 @@ def _(hint: type, value):
 @normalize.register
 def _(hint: list, value):
     if len(hint) != 1:
-        raise InternalError(f'Expected a list of one type element. Got {repr(hint)}.')
+        raise InternalError(f"Expected a list of one type element. Got {repr(hint)}.")
     if isinstance(value, (str, bytes)) or not isinstance(value, collections.abc.Iterable):
-        raise TypeError(f'Expected a list-like value. Got {repr(value)}.')
+        raise TypeError(f"Expected a list-like value. Got {repr(value)}.")
     return [normalize(hint[0], element) for element in value]
 
 
@@ -705,16 +680,17 @@ def _(hint: dict, value):
     try:
         for key in value.keys():
             if key not in hint:
-                raise MissingImplementationError(f'{key} is not a valid field.')
+                raise MissingImplementationError(f"{key} is not a valid field.")
         items: tuple = value.items()
     except AttributeError:
-        raise TypeError(f'Expected a dict-like value. Got {repr(value)}.')
+        raise TypeError(f"Expected a dict-like value. Got {repr(value)}.")
     return {key: normalize(hint[key], val) for key, val in items}
 
 
 class _PilotDescriptionProxy(rp.PilotDescription):
     """Use PilotDescription details to normalize the value types of description fields."""
-    assert hasattr(rp.PilotDescription, '_schema')
+
+    assert hasattr(rp.PilotDescription, "_schema")
     assert isinstance(rp.PilotDescription._schema, dict)
     assert all(map(lambda v: isinstance(v, (type, list, dict, type(None))), rp.PilotDescription._schema.values()))
 
@@ -737,11 +713,11 @@ class _PilotDescriptionProxy(rp.PilotDescription):
             try:
                 hint = cls._schema[key]
             except KeyError:
-                raise MissingImplementationError(f'{key} is not a valid PilotDescription field.')
+                raise MissingImplementationError(f"{key} is not a valid PilotDescription field.")
             if not isinstance(hint, type):
                 # This may be overly aggressive, but at the moment we are only normalizing values from
                 # the command line parser, and we don't have a good way to pre-parse list or dict values.
-                raise MissingImplementationError(f'No handler for {key} field of type {repr(hint)}.')
+                raise MissingImplementationError(f"No handler for {key} field of type {repr(hint)}.")
 
             if isinstance(None, hint) or isinstance(value, hint):
                 yield key, value
@@ -752,14 +728,16 @@ class _PilotDescriptionProxy(rp.PilotDescription):
 async def add_pilot(runtime: Runtime, **kwargs):
     """Get a new rp.Pilot and add it to the Runtime instance."""
     if kwargs:
-        message = f'scalems.radical.runtime.add_pilot() version {scalems.__version__} ' \
-                  + 'does not support keyword arguments ' \
-                  + ', '.join(kwargs.keys())
+        message = (
+            f"scalems.radical.runtime.add_pilot() version {scalems.__version__} "
+            + "does not support keyword arguments "
+            + ", ".join(kwargs.keys())
+        )
         raise MissingImplementationError(message)
     pilot_manager = runtime.pilot_manager()
     task_manager = runtime.task_manager()
     if not pilot_manager or not task_manager:
-        raise ProtocolError(f'Runtime {runtime} is not ready to use.')
+        raise ProtocolError(f"Runtime {runtime} is not ready to use.")
 
     # Note: Consider fetching through the Runtime instance.
     config: Configuration = configuration()
@@ -767,29 +745,22 @@ async def add_pilot(runtime: Runtime, **kwargs):
     to_thread = _utility.get_to_thread()
 
     # Warning: The Pilot ID needs to be unique within the Session.
-    pilot_description = {
-        'uid': f'pilot.{str(uuid.uuid4())}'
-    }
-    pilot_description.update(config.rp_resource_params.get('PilotDescription', {}))
-    pilot_description.update({'resource': config.execution_target})
+    pilot_description = {"uid": f"pilot.{str(uuid.uuid4())}"}
+    pilot_description.update(config.rp_resource_params.get("PilotDescription", {}))
+    pilot_description.update({"resource": config.execution_target})
 
     # TODO: Pilot venv (#90, #94).
     # Currently, Pilot venv must be specified in the JSON file for resource
     # definitions.
     pilot_description = rp.PilotDescription(pilot_description)
-    logger.debug('Submitting PilotDescription {}'.format(repr(
-        pilot_description.as_dict())))
+    logger.debug("Submitting PilotDescription {}".format(repr(pilot_description.as_dict())))
     pilot: rp.Pilot = await asyncio.create_task(
-        to_thread(pilot_manager.submit_pilots, pilot_description),
-        name='submit_pilots'
+        to_thread(pilot_manager.submit_pilots, pilot_description), name="submit_pilots"
     )
-    logger.debug(f'Got Pilot {pilot.uid}: {pilot.as_dict()}')
+    logger.debug(f"Got Pilot {pilot.uid}: {pilot.as_dict()}")
     runtime.pilot(pilot)
 
-    await asyncio.create_task(
-        to_thread(task_manager.add_pilots, pilot),
-        name='add_pilots'
-    )
+    await asyncio.create_task(to_thread(task_manager.add_pilots, pilot), name="add_pilots")
 
     return pilot
 
@@ -805,16 +776,19 @@ class RPDispatchingExecutor(RuntimeManager):
 
     Extends :py:class:`scalems.execution.RuntimeManager`
     """
-    runtime: 'scalems.radical.runtime.Runtime'
+
+    runtime: "scalems.radical.runtime.Runtime"
     """See `scalems.execution.RuntimeManager.runtime`"""
 
-    def __init__(self,
-                 *,
-                 editor_factory: typing.Callable[[], typing.Callable] = None,
-                 datastore: FileStore = None,
-                 loop: asyncio.AbstractEventLoop,
-                 configuration: Configuration,
-                 dispatcher_lock=None):
+    def __init__(
+        self,
+        *,
+        editor_factory: typing.Callable[[], typing.Callable] = None,
+        datastore: FileStore = None,
+        loop: asyncio.AbstractEventLoop,
+        configuration: Configuration,
+        dispatcher_lock=None,
+    ):
         """Create a client side execution manager.
 
         Warning:
@@ -824,20 +798,19 @@ class RPDispatchingExecutor(RuntimeManager):
             the Python (async) context manager protocol.
 
         """
-        if 'RADICAL_PILOT_DBURL' not in os.environ:
-            raise DispatchError('RADICAL Pilot environment is not available.')
+        if "RADICAL_PILOT_DBURL" not in os.environ:
+            raise DispatchError("RADICAL Pilot environment is not available.")
 
-        if not isinstance(configuration.target_venv, str) \
-                or len(configuration.target_venv) == 0:
-            raise ValueError(
-                'Caller must specify a venv to be activated by the execution agent for '
-                'dispatched tasks.')
+        if not isinstance(configuration.target_venv, str) or len(configuration.target_venv) == 0:
+            raise ValueError("Caller must specify a venv to be activated by the execution agent for dispatched tasks.")
 
-        super().__init__(editor_factory=editor_factory,
-                         datastore=datastore,
-                         loop=loop,
-                         configuration=configuration,
-                         dispatcher_lock=dispatcher_lock)
+        super().__init__(
+            editor_factory=editor_factory,
+            datastore=datastore,
+            loop=loop,
+            configuration=configuration,
+            dispatcher_lock=dispatcher_lock,
+        )
 
     @contextlib.contextmanager
     def runtime_configuration(self):
@@ -879,17 +852,16 @@ class RPDispatchingExecutor(RuntimeManager):
         # Get default configuration.
         configuration_dict = dataclasses.asdict(configuration())
         # Update with any internal configuration.
-        if self._runtime_configuration.target_venv is not None and len(
-                self._runtime_configuration.target_venv) > 0:
-            configuration_dict['target_venv'] = self._runtime_configuration.target_venv
+        if self._runtime_configuration.target_venv is not None and len(self._runtime_configuration.target_venv) > 0:
+            configuration_dict["target_venv"] = self._runtime_configuration.target_venv
         if len(self._runtime_configuration.rp_resource_params) > 0:
-            configuration_dict['rp_resource_params'].update(
-                self._runtime_configuration.rp_resource_params)
-        if self._runtime_configuration.execution_target is not None \
-                and len(self._runtime_configuration.execution_target) > 0:
-            configuration_dict[
-                'execution_target'] = self._runtime_configuration.execution_target
-        configuration_dict['datastore'] = self.datastore
+            configuration_dict["rp_resource_params"].update(self._runtime_configuration.rp_resource_params)
+        if (
+            self._runtime_configuration.execution_target is not None
+            and len(self._runtime_configuration.execution_target) > 0
+        ):
+            configuration_dict["execution_target"] = self._runtime_configuration.execution_target
+        configuration_dict["datastore"] = self.datastore
 
         c = Configuration(**configuration_dict)
 
@@ -949,29 +921,27 @@ class RPDispatchingExecutor(RuntimeManager):
             # will exist at a time. We are further assuming that there will probably only
             # be one Task per the lifetime of the dispatcher object.
             # We could choose another approach and change our assumptions, if appropriate.
-            logger.debug('Entering RP dispatching context. Waiting for rp.Session.')
+            logger.debug("Entering RP dispatching context. Waiting for rp.Session.")
 
             _runtime: Runtime = await new_session()
             # At some point soon, we need to track Session ID for the workflow metadata.
             session_id = _runtime.session.uid
             # Do we want to log this somewhere?
             # session_config = copy.deepcopy(self.session.cfg.as_dict())
-            logger.debug('RP dispatcher acquired session {}'.format(session_id))
+            logger.debug("RP dispatcher acquired session {}".format(session_id))
 
-            logger.debug('Launching PilotManager.')
+            logger.debug("Launching PilotManager.")
             pilot_manager = await asyncio.create_task(
-                to_thread(rp.PilotManager, session=_runtime.session),
-                name='get-PilotManager'
+                to_thread(rp.PilotManager, session=_runtime.session), name="get-PilotManager"
             )
-            logger.debug('Got PilotManager {}.'.format(pilot_manager.uid))
+            logger.debug("Got PilotManager {}.".format(pilot_manager.uid))
             _runtime.pilot_manager(pilot_manager)
 
-            logger.debug('Launching TaskManager.')
+            logger.debug("Launching TaskManager.")
             task_manager = await asyncio.create_task(
-                to_thread(rp.TaskManager, session=_runtime.session),
-                name='get-TaskManager'
+                to_thread(rp.TaskManager, session=_runtime.session), name="get-TaskManager"
             )
-            logger.debug(('Got TaskManager {}'.format(task_manager.uid)))
+            logger.debug(("Got TaskManager {}".format(task_manager.uid)))
             _runtime.task_manager(task_manager)
 
             #
@@ -986,9 +956,7 @@ class RPDispatchingExecutor(RuntimeManager):
             # How and when should we update the pilot description?
 
             pilot = await add_pilot(runtime=_runtime)
-            logger.debug('Added Pilot {} to task manager {}.'.format(
-                pilot.uid,
-                _runtime.task_manager().uid))
+            logger.debug("Added Pilot {} to task manager {}.".format(pilot.uid, _runtime.task_manager().uid))
 
             #
             # Get a scheduler task.
@@ -1002,31 +970,28 @@ class RPDispatchingExecutor(RuntimeManager):
                     pre_exec=list(get_pre_exec(config)),
                     task_manager=task_manager,
                     filestore=config.datastore,
-                    scalems_env='scalems_venv',  # TODO: normalize ownership of this name.
+                    scalems_env="scalems_venv",  # TODO: normalize ownership of this name.
                 ),
-                name='get-scheduler'
+                name="get-scheduler",
             )
             # Note that we can derive scheduler_name from self.scheduler.uid in later methods.
         except asyncio.CancelledError as e:
             raise e
         except Exception as e:
-            logger.exception('Exception while connecting RADICAL Pilot.', exc_info=e)
-            raise DispatchError('Failed to launch SCALE-MS master task.') from e
+            logger.exception("Exception while connecting RADICAL Pilot.", exc_info=e)
+            raise DispatchError("Failed to launch SCALE-MS master task.") from e
 
         self.runtime = _runtime
 
         if self.runtime is None or self.runtime.session.closed:
-            raise ProtocolError('Cannot process queue without a RP Session.')
+            raise ProtocolError("Cannot process queue without a RP Session.")
 
         # Launch queue processor (proxy executor).
         # TODO: Make runtime_startup optional. Let it return a resource that is
         #  provided to the normalized run_executor(), or maybe use it to configure the
         #  Submitter that will be provided to the run_executor.
         runner_started = asyncio.Event()
-        runner_task = asyncio.create_task(
-            scalems.execution.manage_execution(
-                self,
-                processing_state=runner_started))
+        runner_task = asyncio.create_task(scalems.execution.manage_execution(self, processing_state=runner_started))
         await runner_started.wait()
         # TODO: Note the expected scope of the runner_task lifetime with respect to
         #  the global state changes (i.e. ContextVars and locks).
@@ -1042,13 +1007,13 @@ class RPDispatchingExecutor(RuntimeManager):
 
         Overrides :py:class:`scalems.execution.RuntimeManager`
         """
-        session: rp.Session = getattr(runtime, 'session', None)
+        session: rp.Session = getattr(runtime, "session", None)
         if session is None or session.closed:
-            logger.error('Runtime Session is already closed?!')
+            logger.error("Runtime Session is already closed?!")
         else:
             if runtime.scheduler is not None:
                 # Cancel the master.
-                logger.debug('Canceling the master scheduling task.')
+                logger.debug("Canceling the master scheduling task.")
                 task_manager = runtime.task_manager()
                 task_manager.cancel_tasks(uids=runtime.scheduler.uid)
                 # Cancel blocks until the task is done so the following wait is
@@ -1056,7 +1021,7 @@ class RPDispatchingExecutor(RuntimeManager):
                 # behavior.
                 # See https://github.com/radical-cybertools/radical.pilot/issues/2336
                 runtime.scheduler.wait(state=rp.FINAL)
-                logger.info(f'Master scheduling task complete: {repr(runtime.scheduler)}.')
+                logger.info(f"Master scheduling task complete: {repr(runtime.scheduler)}.")
                 if runtime.scheduler.stdout:
                     logger.debug(runtime.scheduler.stdout)
                 if runtime.scheduler.stderr:
@@ -1073,12 +1038,12 @@ class RPDispatchingExecutor(RuntimeManager):
             session.close()
 
             if session.closed:
-                logger.debug(f'Session {session.uid} closed.')
+                logger.debug(f"Session {session.uid} closed.")
             else:
-                logger.error(f'Session {session.uid} not closed!')
-        logger.debug('Runtime shut down.')
+                logger.error(f"Session {session.uid} not closed!")
+        logger.debug("Runtime shut down.")
 
-    def updater(self) -> 'WorkflowUpdater':
+    def updater(self) -> "WorkflowUpdater":
         return WorkflowUpdater(executor=self)
 
 
@@ -1096,12 +1061,11 @@ def configuration(*args, **kwargs) -> Configuration:
     """
     # Not thread-safe
     from scalems.radical import parser
+
     if len(args) > 0:
         _set_configuration(*args, **kwargs)
     elif len(kwargs) > 0:
-        _set_configuration(
-            Configuration(**kwargs)
-        )
+        _set_configuration(Configuration(**kwargs))
     elif _configuration.get(None) is None:
         # No config is set yet. Generate with module parser.
         namespace, _ = parser.parse_known_args()
@@ -1109,17 +1073,18 @@ def configuration(*args, **kwargs) -> Configuration:
     return _configuration.get()
 
 
-def executor_factory(manager: scalems.workflow.WorkflowManager,
-                     params: Configuration = None):
+def executor_factory(manager: scalems.workflow.WorkflowManager, params: Configuration = None):
     if params is not None:
         _set_configuration(params)
     params = configuration()
 
-    executor = RPDispatchingExecutor(editor_factory=weakref.WeakMethod(manager.edit_item),
-                                     datastore=manager.datastore(),
-                                     loop=manager.loop(),
-                                     configuration=params,
-                                     dispatcher_lock=manager._dispatcher_lock)
+    executor = RPDispatchingExecutor(
+        editor_factory=weakref.WeakMethod(manager.edit_item),
+        datastore=manager.datastore(),
+        loop=manager.loop(),
+        configuration=params,
+        dispatcher_lock=manager._dispatcher_lock,
+    )
     return executor
 
 
@@ -1129,6 +1094,7 @@ class RPResult:
     Define a return type for Futures or awaitable tasks from
     RADICAL Pilot commands.
     """
+
     # TODO: Provide support for RP-specific versions of standard SCALEMS result types.
 
 
@@ -1140,6 +1106,7 @@ class RPTaskFailure(ScaleMSError):
 
     TODO: What can/should we capture and report from the failed task?
     """
+
     failed_task: dict
 
     def __init__(self, *args, task: rp.Task):
@@ -1171,10 +1138,7 @@ class RPFinalTaskState:
         return self.canceled.is_set() or self.done.is_set() or self.failed.is_set()
 
 
-def _rp_callback(obj: rp.Task,
-                 state,
-                 cb_data: weakref.ReferenceType = None,
-                 final: RPFinalTaskState = None):
+def _rp_callback(obj: rp.Task, state, cb_data: weakref.ReferenceType = None, final: RPFinalTaskState = None):
     """Prototype for RP.Task callback.
 
     To use, partially bind the *final* parameter (with `functools.partial`) to get a
@@ -1183,10 +1147,8 @@ def _rp_callback(obj: rp.Task,
     Register with *task* to be called when the rp.Task state changes.
     """
     if final is None:
-        raise APIError(
-            'This function is strictly for dynamically prepared RP callbacks through '
-            'functools.partial.')
-    logger.debug(f'Callback triggered by {repr(obj)} state change to {repr(state)}.')
+        raise APIError("This function is strictly for dynamically prepared RP callbacks through " "functools.partial.")
+    logger.debug(f"Callback triggered by {repr(obj)} state change to {repr(state)}.")
     try:
         # Note: assertions and exceptions are not useful in RP callbacks.
         if state in (rp.states.DONE, rp.states.CANCELED, rp.states.FAILED):
@@ -1195,7 +1157,7 @@ def _rp_callback(obj: rp.Task,
             # ref = cb_data()
             # tmgr.unregister_callback(cb=ref, metrics='TASK_STATE',
             #                          uid=obj.uid)
-            logger.debug(f'Recording final state {state} for {repr(obj)}')
+            logger.debug(f"Recording final state {state} for {repr(obj)}")
             if state == rp.states.DONE:
                 final.done.set()
             elif state == rp.states.CANCELED:
@@ -1203,14 +1165,12 @@ def _rp_callback(obj: rp.Task,
             elif state == rp.states.FAILED:
                 final.failed.set()
             else:
-                logger.error('Bug: logic error in state cases.')
+                logger.error("Bug: logic error in state cases.")
     except Exception as e:
-        logger.error(f'Exception encountered during rp.Task callback: {repr(e)}')
+        logger.error(f"Exception encountered during rp.Task callback: {repr(e)}")
 
 
-async def _rp_task_watcher(task: rp.Task,  # noqa: C901
-                           final: RPFinalTaskState,
-                           ready: asyncio.Event) -> rp.Task:
+async def _rp_task_watcher(task: rp.Task, final: RPFinalTaskState, ready: asyncio.Event) -> rp.Task:  # noqa: C901
     """Manage the relationship between an RP.Task and a scalems Future.
 
     Cancel the RP.Task if this task or the scalems.Future is canceled.
@@ -1265,39 +1225,35 @@ async def _rp_task_watcher(task: rp.Task,  # noqa: C901
 
             _rp_task_was_complete = task.state in rp.FINAL
 
-            done, pending = await asyncio.wait([event_watcher],
-                                               timeout=60.0,
-                                               return_when=asyncio.FIRST_COMPLETED)
+            done, pending = await asyncio.wait([event_watcher], timeout=60.0, return_when=asyncio.FIRST_COMPLETED)
 
             if _rp_task_was_complete and not event_watcher.done():
                 event_watcher.cancel()
-                raise RPInternalError('RP Callbacks are taking too long to complete. '
-                                      f'Abandoning {repr(task)}. Please report bug.')
+                raise RPInternalError(
+                    f"RP Callbacks are taking too long to complete. Abandoning {repr(task)}. Please report bug."
+                )
 
             if event_watcher in done:
                 assert final
-                logger.debug(f'Handling finalization for RP task {task.uid}.')
+                logger.debug(f"Handling finalization for RP task {task.uid}.")
                 if final.failed.is_set():
                     # TODO(#92): Provide more useful error feedback.
-                    raise RPTaskFailure(f'{task.uid} failed.', task=task)
+                    raise RPTaskFailure(f"{task.uid} failed.", task=task)
                 elif final.canceled.is_set():
                     # Act as if RP called Task.cancel() on us.
                     raise asyncio.CancelledError()
                 assert final.done.is_set()
 
-                logger.debug(
-                    f'Publishing results from RP Task {task.uid}.')
+                logger.debug(f"Publishing results from RP Task {task.uid}.")
                 # TODO: Manage result type.
                 return task
 
-        raise scalems.exceptions.InternalError(
-            'Logic error. This line should not have been reached.')
+        raise scalems.exceptions.InternalError("Logic error. This line should not have been reached.")
 
     except asyncio.CancelledError as e:
-        logger.debug(
-            f'Received cancellation in watcher task for {repr(task)}')
+        logger.debug(f"Received cancellation in watcher task for {repr(task)}")
         if task.state not in rp.CANCELED:
-            logger.debug(f'Propagating cancellation to {repr(task)}.')
+            logger.debug(f"Propagating cancellation to {repr(task)}.")
             task.cancel()
         raise e
 
@@ -1332,7 +1288,7 @@ async def rp_task(rptask: rp.Task) -> asyncio.Task:
         A Task that, when awaited, returns the rp.Task instance in its final state.
     """
     if not isinstance(rptask, rp.Task):
-        raise TypeError('Function requires a RADICAL Pilot Task object.')
+        raise TypeError("Function requires a RADICAL Pilot Task object.")
 
     final = RPFinalTaskState()
     callback = functools.partial(_rp_callback, final=final)
@@ -1349,18 +1305,15 @@ async def rp_task(rptask: rp.Task) -> asyncio.Task:
     if rptask.state in rp.FINAL:
         # rptask may have reached FINAL state before callback was registered.
         # Call it once. For simplicity, let the task_watcher logic proceed normally.
-        logger.warning(f'RP Task {repr(rptask)} finished suspiciously fast.')
+        logger.warning(f"RP Task {repr(rptask)} finished suspiciously fast.")
         callback(rptask, rptask.state, cb_data)
 
     watcher_started = asyncio.Event()
     waiter = asyncio.create_task(watcher_started.wait())
-    wrapped_task = asyncio.create_task(_rp_task_watcher(task=rptask,
-                                                        final=final,
-                                                        ready=watcher_started))
+    wrapped_task = asyncio.create_task(_rp_task_watcher(task=rptask, final=final, ready=watcher_started))
 
     # Make sure that the task is cancellable before returning it to the caller.
-    await asyncio.wait((waiter, wrapped_task),
-                       return_when=asyncio.FIRST_COMPLETED)
+    await asyncio.wait((waiter, wrapped_task), return_when=asyncio.FIRST_COMPLETED)
     if wrapped_task.done():
         # Let CancelledError propagate.
         e = wrapped_task.exception()
@@ -1370,24 +1323,27 @@ async def rp_task(rptask: rp.Task) -> asyncio.Task:
     return wrapped_task
 
 
-def _describe_legacy_task(item: scalems.workflow.Task,
-                          pre_exec: list) -> rp.TaskDescription:
+def _describe_legacy_task(item: scalems.workflow.Task, pre_exec: list) -> rp.TaskDescription:
     """Derive a RADICAL Pilot TaskDescription from a scalems workflow item.
 
     For a "raptor" style task, see _describe_raptor_task()
     """
-    subprocess_type = TypeIdentifier(('scalems', 'subprocess', 'SubprocessTask'))
+    subprocess_type = TypeIdentifier(("scalems", "subprocess", "SubprocessTask"))
     assert item.description().type() == subprocess_type
     input_data = item.input
     task_input = scalems.subprocess.SubprocessInput(**input_data)
     args = list([arg for arg in task_input.argv])
     # Warning: TaskDescription class does not have a strongly defined interface.
     # Check docs for schema.
-    task_description = rp.TaskDescription(from_dict=dict(executable=args[0],
-                                                         arguments=args[1:],
-                                                         stdout=str(task_input.stdout),
-                                                         stderr=str(task_input.stderr),
-                                                         pre_exec=pre_exec))
+    task_description = rp.TaskDescription(
+        from_dict=dict(
+            executable=args[0],
+            arguments=args[1:],
+            stdout=str(task_input.stdout),
+            stderr=str(task_input.stderr),
+            pre_exec=pre_exec,
+        )
+    )
     uid: str = item.uid().hex()
     task_description.uid = uid
 
@@ -1399,23 +1355,24 @@ def _describe_legacy_task(item: scalems.workflow.Task,
 
     # TODO: Interpret item details and derive appropriate staging directives.
     task_description.input_staging = list(task_input.inputs.values())
-    task_description.output_staging = [{
-        'source': str(task_input.stdout),
-        'target': os.path.join(uid, pathlib.Path(task_input.stdout).name),
-        'action': rp.TRANSFER
-    }, {
-        'source': str(task_input.stderr),
-        'target': os.path.join(uid, pathlib.Path(task_input.stderr).name),
-        'action': rp.TRANSFER
-    }]
+    task_description.output_staging = [
+        {
+            "source": str(task_input.stdout),
+            "target": os.path.join(uid, pathlib.Path(task_input.stdout).name),
+            "action": rp.TRANSFER,
+        },
+        {
+            "source": str(task_input.stderr),
+            "target": os.path.join(uid, pathlib.Path(task_input.stderr).name),
+            "action": rp.TRANSFER,
+        },
+    ]
     task_description.output_staging += task_input.outputs.values()
 
     return task_description
 
 
-def _describe_raptor_task(item: scalems.workflow.Task,
-                          scheduler: str,
-                          pre_exec: list) -> rp.TaskDescription:
+def _describe_raptor_task(item: scalems.workflow.Task, scheduler: str, pre_exec: list) -> rp.TaskDescription:
     """Derive a RADICAL Pilot TaskDescription from a scalems workflow item.
 
     The TaskDescription will be submitted to the named *scheduler*,
@@ -1428,10 +1385,7 @@ def _describe_raptor_task(item: scalems.workflow.Task,
     # Check docs for schema.
     # Ref: scalems_rp_master._RaptorTaskDescription
     task_description = rp.TaskDescription(
-        from_dict=dict(
-            executable='scalems',  # This value is currently ignored, but must be set.
-            pre_exec=pre_exec
-        )
+        from_dict=dict(executable="scalems", pre_exec=pre_exec)  # This value is currently ignored, but must be set.
     )
     task_description.uid = item.uid()
     task_description.scheduler = str(scheduler)
@@ -1450,13 +1404,10 @@ def _describe_raptor_task(item: scalems.workflow.Task,
     #     'data': item.serialize()
     # }
     work_dict = {
-        'mode': 'exec',
-        'cores': 1,
-        'timeout': None,
-        'data': {
-            'exe': item.input['argv'][0],
-            'args': item.input['argv'][1:]
-        }
+        "mode": "exec",
+        "cores": 1,
+        "timeout": None,
+        "data": {"exe": item.input["argv"][0], "args": item.input["argv"][1:]},
     }
     task_description.arguments = [json.dumps(work_dict)]
 
@@ -1473,11 +1424,9 @@ def _describe_raptor_task(item: scalems.workflow.Task,
     return task_description
 
 
-async def submit(*,
-                 item: scalems.workflow.Task,
-                 task_manager: rp.TaskManager,
-                 pre_exec: list,
-                 scheduler: str = None) -> asyncio.Task:
+async def submit(
+    *, item: scalems.workflow.Task, task_manager: rp.TaskManager, pre_exec: list, scheduler: str = None
+) -> asyncio.Task:
     """Dispatch a WorkflowItem to be handled by RADICAL Pilot.
 
     Submits an rp.Task and returns an asyncio.Task watcher for the submitted task.
@@ -1538,20 +1487,20 @@ async def submit(*,
 
     # TODO: Optimization: skip tasks that are already done (cached results available).
     def scheduler_is_ready(scheduler):
-        return isinstance(scheduler, str) \
-               and len(scheduler) > 0 \
-               and isinstance(task_manager.get_tasks(scheduler), rp.Task)
+        return (
+            isinstance(scheduler, str) and len(scheduler) > 0 and isinstance(task_manager.get_tasks(scheduler), rp.Task)
+        )
 
-    subprocess_type = TypeIdentifier(('scalems', 'subprocess', 'SubprocessTask'))
+    subprocess_type = TypeIdentifier(("scalems", "subprocess", "SubprocessTask"))
     if item.description().type() == subprocess_type:
         if scheduler is not None:
-            raise DispatchError('Raptor not yet supported for scalems.executable.')
+            raise DispatchError("Raptor not yet supported for scalems.executable.")
         rp_task_description = _describe_legacy_task(item, pre_exec=pre_exec)
     elif scheduler_is_ready(scheduler):
         # We might want a contextvars.Context to hold the current rp.Master instance name.
         rp_task_description = _describe_raptor_task(item, scheduler, pre_exec=pre_exec)
     else:
-        raise APIError('Caller must provide the UID of a submitted *scheduler* task.')
+        raise APIError("Caller must provide the UID of a submitted *scheduler* task.")
 
     # TODO(#249): A utility function to move slow blocking RP calls to a separate thread.
     #  Compartmentalize TaskDescription -> rp_task_watcher in a separate utility function.
@@ -1561,17 +1510,15 @@ async def submit(*,
 
     if rp_task_watcher.done():
         if rp_task_watcher.cancelled():
-            raise DispatchError(f'Task for {item} was unexpectedly canceled during '
-                                'dispatching.')
+            raise DispatchError(f"Task for {item} was unexpectedly canceled during dispatching.")
         e = rp_task_watcher.exception()
         if e is not None:
-            raise DispatchError('Task for {item} failed during dispatching.') from e
+            raise DispatchError("Task for {item} failed during dispatching.") from e
 
     # Warning: in the long run, we should not extend the life of the reference returned
     # by edit_item, and we need to consider the robust way to publish item results.
     # TODO: Translate RP result to item result type.
-    rp_task_watcher.add_done_callback(functools.partial(scalems_callback,
-                                                        item=item))
+    rp_task_watcher.add_done_callback(functools.partial(scalems_callback, item=item))
     # TODO: If *item* acquires a `cancel` method, we need to subscribe to it and
     #  respond by unregistering the callback and canceling the future.
 
@@ -1594,13 +1541,13 @@ def scalems_callback(fut: asyncio.Future, *, item: scalems.workflow.Task):
     """
     assert fut.done()
     if fut.cancelled():
-        logger.info(f'Task supporting {item} has been cancelled.')
+        logger.info(f"Task supporting {item} has been cancelled.")
     else:
         # The following should not throw because we just checked for `done()` and
         # `cancelled()`
         e = fut.exception()
         if e:
-            logger.info(f'Task supporting {item} failed: {e}')
+            logger.info(f"Task supporting {item} failed: {e}")
         else:
             # TODO: Construct an appropriate scalems Result from the rp Task.
             item.set_result(fut.result())
@@ -1618,10 +1565,7 @@ class WorkflowUpdater(AbstractWorkflowUpdater):
         # TODO: Ensemble handling
         item_shape = item.description().shape()
         if len(item_shape) != 1 or item_shape[0] != 1:
-            raise MissingImplementationError(
-                'Executor cannot handle multidimensional tasks yet.')
+            raise MissingImplementationError("Executor cannot handle multidimensional tasks yet.")
 
-        task: asyncio.Task[rp.Task] = await submit(item=item,
-                                                   task_manager=self.task_manager,
-                                                   pre_exec=self._pre_exec)
+        task: asyncio.Task[rp.Task] = await submit(item=item, task_manager=self.task_manager, pre_exec=self._pre_exec)
         return task

--- a/src/scalems/serialization.py
+++ b/src/scalems/serialization.py
@@ -16,7 +16,7 @@ JSON, such as the CWL schema.
 """
 from __future__ import annotations
 
-__all__ = ['BasicSerializable', 'decode', 'encode', 'Shape']
+__all__ = ["BasicSerializable", "decode", "encode", "Shape"]
 
 import abc
 import collections.abc
@@ -38,7 +38,7 @@ from scalems.identifiers import TypeDataDescriptor
 from scalems.identifiers import TypeIdentifier
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 
 class Shape(tuple):
@@ -57,11 +57,12 @@ class Shape(tuple):
         except TypeError as e:
             raise e
         if len(es) < 1 or any(not isinstance(e, int) for e in es):
-            raise TypeError('Shape is a sequence of 1 or more integers.')
+            raise TypeError("Shape is a sequence of 1 or more integers.")
 
 
 # It could make sense to split the codec for native-Python encoding from the
 # (de)serialization code in the future...
+
 
 class SchemaDict(typing.TypedDict):
     """Schema for the member that labels an object's schema.
@@ -79,6 +80,7 @@ class SchemaDict(typing.TypedDict):
     TODO: Allow equality check
     TODO: Actually integrate with object support metaprogramming in the package.
     """
+
     spec: str
     name: str
 
@@ -92,6 +94,7 @@ ShapeElement = typing.Union[int, SymbolicDimensionSize]
 
 class FieldDict(typing.TypedDict):
     """Members of the *fields* member of a ResourceType."""
+
     schema: SchemaDict
     type: typing.List[str]
     shape: typing.List[ShapeElement]
@@ -102,6 +105,7 @@ FieldsType = typing.Mapping[str, FieldDict]
 
 class TypeDict(typing.TypedDict):
     """Express the expected contents of a dictionary-based type description."""
+
     schema: SchemaDict
     implementation: typing.List[str]
     fields: FieldsType
@@ -121,12 +125,13 @@ class Encoded(typing.Protocol):
             bool,
             type(None)]]
     """
+
     # TODO: How should we implement this?
 
 
-DispatchT = typing.TypeVar('DispatchT')
-ResultT = typing.TypeVar('ResultT')
-S = typing.TypeVar('S')
+DispatchT = typing.TypeVar("DispatchT")
+ResultT = typing.TypeVar("ResultT")
+S = typing.TypeVar("S")
 
 
 class Serializable(abc.ABC):
@@ -171,6 +176,7 @@ class PythonEncoder:
 
     Alternatively, encode object(s) first, and pass the resulting Python object to a regular call to json.dumps.
     """
+
     # Note that the following are equivalent.
     #     json.loads(s, *, cls=None, **kw)
     #     json.JSONDecoder(**kw).decode(s)
@@ -180,17 +186,18 @@ class PythonEncoder:
 
     # We use WeakKeyDictionary because the keys are likely to be classes,
     # and we don't intend to extend the life of the type objects (which might be temporary).
-    _dispatchers: typing.ClassVar[typing.MutableMapping[
-        type, typing.Callable[[DispatchT], BaseEncodable]]] = weakref.WeakKeyDictionary()
+    _dispatchers: typing.ClassVar[
+        typing.MutableMapping[type, typing.Callable[[DispatchT], BaseEncodable]]
+    ] = weakref.WeakKeyDictionary()
 
     @classmethod
     def register(cls, dtype: typing.Type[DispatchT], handler: typing.Callable[[DispatchT], BaseEncodable]):
         # Note that we don't expect references to bound methods to extend the life of the type.
         # TODO: confirm this assumption in a unit test.
         if not isinstance(dtype, type):
-            raise TypeError('We use `isinstance(obj, dtype)` for dispatching, so *dtype* must be a `type` object.')
+            raise TypeError("We use `isinstance(obj, dtype)` for dispatching, so *dtype* must be a `type` object.")
         if dtype in cls._dispatchers:
-            raise ProtocolError(f'Encodable type {dtype} appears to be registered already.')
+            raise ProtocolError(f"Encodable type {dtype} appears to be registered already.")
         cls._dispatchers[dtype] = handler
 
     @classmethod
@@ -209,7 +216,7 @@ class PythonEncoder:
         for dtype, dispatch in cls._dispatchers.items():
             if isinstance(obj, typing.cast(type, dtype)):
                 return dispatch(obj)
-        raise TypeError(f'No registered dispatching for {repr(obj)}')
+        raise TypeError(f"No registered dispatching for {repr(obj)}")
 
     def __call__(self, obj) -> BaseEncodable:
         return self.encode(obj)
@@ -252,9 +259,8 @@ class PythonDecoder:
      * https://packaging.python.org/guides/creating-and-discovering-plugins/
      * https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html#dynamic-discovery-of-services-and-plugins
     """
-    _dispatchers: typing.MutableMapping[
-        TypeIdentifier,
-        typing.Callable] = dict()
+
+    _dispatchers: typing.MutableMapping[TypeIdentifier, typing.Callable] = dict()
 
     # Depending on what the callables are, we may want a weakref.WeakValueDictionary() or we may not!
 
@@ -263,7 +269,7 @@ class PythonDecoder:
         # Normalize typeid
         typeid = TypeIdentifier.copy_from(typeid)
         if typeid in cls._dispatchers:
-            raise ProtocolError('Type appears to be registered already.')
+            raise ProtocolError("Type appears to be registered already.")
         cls._dispatchers[typeid] = handler
 
     @classmethod
@@ -285,7 +291,7 @@ class PythonDecoder:
             identifier = None
         # Use the (hashable) normalized form to look up a decoder for dispatching.
         if identifier is None or identifier not in cls._dispatchers:
-            raise TypeError('No decoder registered for {}'.format(typename))
+            raise TypeError("No decoder registered for {}".format(typename))
         return cls._dispatchers[identifier]
 
     @classmethod
@@ -306,30 +312,31 @@ class PythonDecoder:
             ...
         else:
             assert isinstance(obj, dict)
-            if 'schema' in obj:
+            if "schema" in obj:
                 # We currently have very limited schema processing.
                 try:
-                    spec = obj['schema']['spec']
+                    spec = obj["schema"]["spec"]
                 except KeyError:
                     spec = None
-                if not isinstance(spec, str) or spec != 'scalems.v0':
+                if not isinstance(spec, str) or spec != "scalems.v0":
                     # That's fine...
-                    logger.info('Unrecognized *schema* when decoding object.')
+                    logger.info("Unrecognized *schema* when decoding object.")
                     return obj
-                if 'name' not in obj['schema'] or not isinstance(obj['schema']['name'], str):
-                    raise InternalError('Invalid schema.')
+                if "name" not in obj["schema"] or not isinstance(obj["schema"]["name"], str):
+                    raise InternalError("Invalid schema.")
                 else:
                     # schema = obj['schema']['name']
                     ...
                 # Dispatch the object...
                 ...
                 raise MissingImplementationError(
-                    'We do not yet support dynamic type registration through the work record.')
+                    "We do not yet support dynamic type registration through the work record."
+                )
 
-            if 'type' in obj:
+            if "type" in obj:
                 # Dispatch the decoding according to the type.
                 try:
-                    dispatch = cls.get_decoder(obj['type'])
+                    dispatch = cls.get_decoder(obj["type"])
                 except TypeError:
                     dispatch = BasicSerializable.decode
                 if dispatch is not None:
@@ -359,7 +366,7 @@ encode.register(dtype=os.PathLike, handler=os.fsdecode)
 
 # A SCALE-MS "Serializable Type".
 # TODO: use a Protocol or other constraint.
-ST = typing.TypeVar('ST', bound='BasicSerializable')
+ST = typing.TypeVar("ST", bound="BasicSerializable")
 
 
 class BasicSerializable(UnboundObject):
@@ -371,7 +378,7 @@ class BasicSerializable(UnboundObject):
     _data_encoder: typing.Callable
     _data_decoder: typing.Callable
 
-    _dtype = TypeDataDescriptor(base_type=TypeIdentifier(('scalems', 'BasicSerializable')))
+    _dtype = TypeDataDescriptor(base_type=TypeIdentifier(("scalems", "BasicSerializable")))
 
     def dtype(self) -> TypeIdentifier:
         # Part of the decision of whether to use a property or a method
@@ -409,55 +416,50 @@ class BasicSerializable(UnboundObject):
 
     def encode(self) -> dict:
         representation = {
-            'label': self.label(),
-            'identity': str(self.identity()),
-            'type': self.dtype().encode(),
-            'shape': tuple(self.shape()),
-            'data': self.data  # TODO: use self._data_encoder()
+            "label": self.label(),
+            "identity": str(self.identity()),
+            "type": self.dtype().encode(),
+            "shape": tuple(self.shape()),
+            "data": self.data,  # TODO: use self._data_encoder()
         }
         return representation
 
     @classmethod
     def decode(cls: typing.Type[ST], encoded: dict) -> ST:
-        if not isinstance(encoded, collections.abc.Mapping) or 'type' not in encoded:
-            raise TypeError('Expected a dictionary with a *type* specification for decoding.')
-        dtype = TypeIdentifier.copy_from(encoded['type'])
-        label = encoded.get('label', None)
-        identity = encoded.get('identity')  # TODO: verify and use type schema to decode.
-        shape = Shape(encoded['shape'])
-        data = encoded['data']  # TODO: use type schema / self._data_decoder to decode.
-        logger.debug(f'Decoding {identity} as BasicSerializable.')
-        return cls(label=label,
-                   identity=identity,
-                   dtype=dtype,
-                   shape=shape,
-                   data=data
-                   )
+        if not isinstance(encoded, collections.abc.Mapping) or "type" not in encoded:
+            raise TypeError("Expected a dictionary with a *type* specification for decoding.")
+        dtype = TypeIdentifier.copy_from(encoded["type"])
+        label = encoded.get("label", None)
+        identity = encoded.get("identity")  # TODO: verify and use type schema to decode.
+        shape = Shape(encoded["shape"])
+        data = encoded["data"]  # TODO: use type schema / self._data_decoder to decode.
+        logger.debug(f"Decoding {identity} as BasicSerializable.")
+        return cls(label=label, identity=identity, dtype=dtype, shape=shape, data=data)
 
     def __init_subclass__(cls, **kwargs):
         assert cls is not BasicSerializable
 
         # Handle SCALE-MS Type registration.
-        base = kwargs.pop('base_type', None)
+        base = kwargs.pop("base_type", None)
         if base is not None:
             typeid = TypeIdentifier.copy_from(base)
         else:
-            typeid = [str(cls.__module__)] + cls.__qualname__.split('.')
+            typeid = [str(cls.__module__)] + cls.__qualname__.split(".")
         registry = BasicSerializable._dtype.base
         if cls in registry and registry[cls] is not None:
             # This may be a customization or extension point in the future, but not today...
-            raise ProtocolError('Subclassing BasicSerializable for a Type that is already registered.')
+            raise ProtocolError("Subclassing BasicSerializable for a Type that is already registered.")
         BasicSerializable._dtype.base[cls] = typeid
 
         # Register encoder for all subclasses. Register the default encoder if not overridden.
         # Note: This does not allow us to retain the identity of *cls* for when we call the helpers.
         # We may require such information for encoder functions to know why they are being called.
-        encoder = getattr(cls, 'encode', BasicSerializable.encode)
+        encoder = getattr(cls, "encode", BasicSerializable.encode)
         PythonEncoder.register(cls, encoder)
 
         # Optionally, register a new decoder.
         # If no decoder is provided, use the basic decoder.
-        if hasattr(cls, 'decode') and callable(cls.decode):
+        if hasattr(cls, "decode") and callable(cls.decode):
             _decoder = weakref.WeakMethod(cls.decode)
 
             # Note that we do not require that the decoded object is actually
@@ -466,7 +468,7 @@ class BasicSerializable(UnboundObject):
             def _decode(encoded: dict):
                 decoder = _decoder()
                 if decoder is None:
-                    raise ProtocolError('Decoding a type that has already been de-registered.')
+                    raise ProtocolError("Decoding a type that has already been de-registered.")
                 return decoder(encoded)
 
             PythonDecoder.register(cls._dtype, _decode)
@@ -494,12 +496,7 @@ class BasicSerializable(UnboundObject):
 def compact_json(obj) -> str:
     """Produce the compact JSON string for the encodable object."""
     # Use the extensible Encoder from the serialization module, but apply some output formatting.
-    string = json.dumps(obj,
-                        default=encode,
-                        ensure_ascii=True,
-                        separators=(',', ':'),
-                        sort_keys=True
-                        )
+    string = json.dumps(obj, default=encode, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
     return string
 
 

--- a/src/scalems/subprocess/__init__.py
+++ b/src/scalems/subprocess/__init__.py
@@ -15,14 +15,14 @@ in terms of standard types. In a follow-up, we can use a scalems metaclass to de
 in terms of Data Descriptors that support mixed scalems.Future and native constant data types.
 """
 
-__all__ = ['executable', 'Subprocess', 'SubprocessInput', 'SubprocessResult']
+__all__ = ["executable", "Subprocess", "SubprocessInput", "SubprocessResult"]
 
 import logging
 
 from . import _subprocess
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 Subprocess = _subprocess.Subprocess
 SubprocessInput = _subprocess.SubprocessInput

--- a/src/scalems/subprocess/_subprocess.py
+++ b/src/scalems/subprocess/_subprocess.py
@@ -15,7 +15,7 @@ in terms of standard types. In a follow-up, we can use a scalems metaclass to de
 in terms of Data Descriptors that support mixed scalems.Future and native constant data types.
 """
 
-__all__ = ['executable', 'Subprocess', 'SubprocessInput', 'SubprocessResult']
+__all__ = ["executable", "Subprocess", "SubprocessInput", "SubprocessResult"]
 
 import dataclasses
 import json
@@ -32,7 +32,7 @@ from ..exceptions import MissingImplementationError
 from ..workflow import WorkflowManager
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 
 class OutputFile(dict):
@@ -51,18 +51,18 @@ class OutputFile(dict):
     into workflow references that are dependent on the task under construction.
     """
 
-    def __init__(self, label=None, suffix=''):
+    def __init__(self, label=None, suffix=""):
         super().__init__()
-        self['label'] = label
-        self['suffix'] = suffix
+        self["label"] = label
+        self["suffix"] = suffix
 
     @property
     def label(self):
-        return self.get('label', None)
+        return self.get("label", None)
 
     @property
     def suffix(self):
-        return self.get('suffix', '')
+        return self.get("suffix", "")
 
 
 # TODO: what is the mechanism for registering a command implementation in a new Context?
@@ -79,8 +79,8 @@ class SubprocessInput:
     stdin: typing.Iterable[str] = ()
     environment: typing.Mapping[str, typing.Union[str, None]] = dataclasses.field(default_factory=dict)
     # For now, let's just always enable stdout/stderr
-    stdout: Path = dataclasses.field(default=Path('stdout'))
-    stderr: Path = dataclasses.field(default=Path('stderr'))
+    stdout: Path = dataclasses.field(default=Path("stdout"))
+    stderr: Path = dataclasses.field(default=Path("stderr"))
     resources: typing.Mapping[str, typing.Any] = dataclasses.field(default_factory=dict)
 
 
@@ -96,9 +96,9 @@ def _(item: SubprocessInput, *, manager: WorkflowManager, label: str = None):
     def director(*args, **kwargs):
         if len(args) > 0:
             # TODO: Reconsider reasonable exceptions.
-            raise TypeError('Unexpected positional arguments.')
+            raise TypeError("Unexpected positional arguments.")
         if len(kwargs) > 0:
-            raise TypeError('Unexpected key word arguments: {}'.format(', '.join(kwargs.keys())))
+            raise TypeError("Unexpected key word arguments: {}".format(", ".join(kwargs.keys())))
         uid = hash(item)
         if uid in manager.tasks:
             # TODO: Consider whether this is the correct behavior
@@ -128,11 +128,11 @@ class SubprocessTask:
     def scoped_identifier(cls):
         # TODO: Consider either deriving from the `import` identifier,
         #       or defining a more sophisticated protocol for name resolution.
-        return ('scalems', 'subprocess', 'SubprocessTask')
+        return ("scalems", "subprocess", "SubprocessTask")
 
     @classmethod
     def identifier(cls):
-        return '.'.join(cls.scoped_identifier())
+        return ".".join(cls.scoped_identifier())
 
     @classmethod
     def input_type(cls) -> type:
@@ -163,7 +163,7 @@ class Subprocess:
         self._result = None
         self._uid = uid
         if self._uid is None:
-            self._uid = next_monotonic_integer().to_bytes(32, 'big')
+            self._uid = next_monotonic_integer().to_bytes(32, "big")
 
     def input_collection(self):
         return self._bound_input
@@ -185,16 +185,16 @@ class Subprocess:
         for bound objects, if they exist.
         """
         record = {}
-        record['uid'] = self.uid().hex()
+        record["uid"] = self.uid().hex()
         # "label" not yet supported.
-        record['type'] = self.resource_type().scoped_identifier()
-        record['input'] = dataclasses.asdict(self._bound_input)  # reference
-        record['result'] = dataclasses.asdict(self._result)  # reference
+        record["type"] = self.resource_type().scoped_identifier()
+        record["input"] = dataclasses.asdict(self._bound_input)  # reference
+        record["result"] = dataclasses.asdict(self._result)  # reference
         try:
             serialized = json.dumps(record, default=encode)
         except TypeError as e:
-            logger.critical('Missing encoding logic for scalems data. Encoder says ' + str(e))
-            raise InternalError('Missing serialization support.') from e
+            logger.critical("Missing encoding logic for scalems data. Encoder says " + str(e))
+            raise InternalError("Missing serialization support.") from e
 
         # raise MissingImplementationError('To do...')
         return serialized
@@ -266,14 +266,14 @@ class Subprocess:
 @scalems.workflow.workflow_item_director_factory.register
 def _(item: Subprocess, *, manager: scalems.workflow.WorkflowManager, label: str = None):
     if not isinstance(manager, scalems.workflow.WorkflowManager):
-        raise APIError(f'No director for {repr(manager)}')
+        raise APIError(f"No director for {repr(manager)}")
 
     def director(*args, **kwargs):
         if len(args) > 0:
             # TODO: Reconsider reasonable exceptions.
-            raise TypeError('Unexpected positional arguments.')
+            raise TypeError("Unexpected positional arguments.")
         if len(kwargs) > 0:
-            raise TypeError('Unexpected key word arguments: {}'.format(', '.join(kwargs.keys())))
+            raise TypeError("Unexpected key word arguments: {}".format(", ".join(kwargs.keys())))
 
         # Note regarding registering task implementation functions:
         # scalems.subprocess is a very special kind of task. Each execution
@@ -384,9 +384,8 @@ def executable(*args, manager: scalems.workflow.WorkflowManager = None, **kwargs
     input_type = Subprocess.resource_type().input_type()
     if not isinstance(input_type, type):
         raise InternalError(
-            'Bug: {} is not coded correctly for the {}.input_type() interface.'.format(
-                __name__,
-                str(type(Subprocess.resource_type()))
+            "Bug: {} is not coded correctly for the {}.input_type() interface.".format(
+                __name__, str(type(Subprocess.resource_type()))
             )
         )
 
@@ -410,13 +409,13 @@ def executable(*args, manager: scalems.workflow.WorkflowManager = None, **kwargs
     try:
         task_view: scalems.workflow.ItemView = director(input=bound_input)
     except TypeError as e:
-        logger.error('Invalid input in SubprocessInput: ' + str(e))
+        logger.error("Invalid input in SubprocessInput: " + str(e))
         raise
     except json.JSONDecodeError as e:
-        logger.critical('Malformed data: ' + e.msg)
-        raise InternalError('Bug: internal data is not being conditioned properly') from e
+        logger.critical("Malformed data: " + e.msg)
+        raise InternalError("Bug: internal data is not being conditioned properly") from e
     except Exception as e:
-        logger.critical('Unhandled ' + repr(e))
+        logger.critical("Unhandled " + repr(e))
         raise
 
     # TODO: The returned value should be a TaskView provided by the Context with

--- a/src/scalems/wrappers/gromacs.py
+++ b/src/scalems/wrappers/gromacs.py
@@ -5,7 +5,7 @@ Preparation and output manipulation use command line tools.
 Simulation is executed with gmxapi.
 """
 # Declare the public interface of this wrapper module.
-__all__ = ['make_input', 'modify_input', 'simulate']
+__all__ = ["make_input", "modify_input", "simulate"]
 
 ##########################
 # New plan:
@@ -19,6 +19,7 @@ __all__ = ['make_input', 'modify_input', 'simulate']
 ###########################
 import functools
 import logging
+
 # import gmxapi
 import os
 import pathlib
@@ -31,24 +32,25 @@ from scalems.utility import next_monotonic_integer as _next_int
 from scalems.workflow import WorkflowManager
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 
 # TODO: REMOVE. Follow with fingerprint based UID ASAP.
 def _next_uid() -> bytes:
     # Note that network byte order is equivalent to "big endian".
-    return _next_int().to_bytes(32, 'big')
+    return _next_int().to_bytes(32, "big")
 
 
-def _executable(argv: Sequence[str],
-                inputs: Sequence[str] = (),
-                outputs: Sequence[str] = (),
-                stdin: typing.Iterable[str] = (),
-                resources: typing.Mapping[str, str] = None,
-                environment: typing.Mapping[str, str] = None,
-                stdout: str = 'stdout.txt',
-                stderr: str = 'stderr.txt'
-                ):
+def _executable(
+    argv: Sequence[str],
+    inputs: Sequence[str] = (),
+    outputs: Sequence[str] = (),
+    stdin: typing.Iterable[str] = (),
+    resources: typing.Mapping[str, str] = None,
+    environment: typing.Mapping[str, str] = None,
+    stdout: str = "stdout.txt",
+    stderr: str = "stderr.txt",
+):
     if resources is None:
         resources = {}
     if environment is None:
@@ -56,59 +58,52 @@ def _executable(argv: Sequence[str],
 
     input_node = {
         # Static properties.
-        'object_type': 'ExecutableInput',
-        'uid': _next_uid().hex(),
+        "object_type": "ExecutableInput",
+        "uid": _next_uid().hex(),
         # Fields may have dependencies.
-        'data': {
-            'argv': list(argv),
-            'inputs': list(inputs),
-            'stdin': stdin,
-            'environment': dict(**environment)
-        }
+        "data": {"argv": list(argv), "inputs": list(inputs), "stdin": stdin, "environment": dict(**environment)},
     }
     # Results are self-referential until a concrete result is available.
-    input_node['result'] = input_node['uid']
+    input_node["result"] = input_node["uid"]
 
     task_node: dict = {
         # Static properties.
-        'object_type': 'Executable',
-        'uid': _next_uid().hex(),
-        'data': {
-            'stdout': 'stdout.txt',
-            'stderr': 'stderr.txt',
+        "object_type": "Executable",
+        "uid": _next_uid().hex(),
+        "data": {
+            "stdout": "stdout.txt",
+            "stderr": "stderr.txt",
         },
         # Fields may have dependencies.
-        'input': {
-            'ExecutableInput': input_node['uid'],
-            'resources': dict(**resources),
+        "input": {
+            "ExecutableInput": input_node["uid"],
+            "resources": dict(**resources),
             # The files produced by a program may depend on the inputs, so this is
             # not static. We will archive the whole working directory, but we can
             # use this file list to do additional checks for task success and allow
             # tighter output binding.
-            'output': list(outputs),
+            "output": list(outputs),
         },
     }
-    task_node['result'] = task_node['uid']
+    task_node["result"] = task_node["uid"]
 
     output_node: dict = {
-        'object_type': 'ExecutableOutput',
-        'uid': _next_uid().hex(),
-        'input': {
+        "object_type": "ExecutableOutput",
+        "uid": _next_uid().hex(),
+        "input": {
             # Explicit dependency that is not (yet) resolved in terms of data flow.
-            'depends': task_node['uid'],
+            "depends": task_node["uid"],
             # Fields with dependencies, though not evident in this example.
-            'outputs': list(outputs),
-            'stdout': stdout,
-            'stderr': stderr
+            "outputs": list(outputs),
+            "stdout": stdout,
+            "stderr": stderr,
         },
     }
-    output_node['result'] = output_node['uid']
+    output_node["result"] = output_node["uid"]
 
     return {
-        'implementation': ['scalems', 'wrappers', 'gromacs', 'Executable'],
-        'message': {
-            'Executable': [input_node, task_node, output_node]
-        }
+        "implementation": ["scalems", "wrappers", "gromacs", "Executable"],
+        "message": {"Executable": [input_node, task_node, output_node]},
     }
 
 
@@ -120,7 +115,7 @@ except ImportError:
     cli_executable = None
     _gmx_cli_entry_point = None
 if _gmx_cli_entry_point is None:
-    _gmx_cli_entry_point = 'gmx'
+    _gmx_cli_entry_point = "gmx"
 
 
 # TODO: Implicit ensemble handling requires type annotations.
@@ -128,40 +123,39 @@ if _gmx_cli_entry_point is None:
 #                topology=['md.top'],
 #                conformation=['md.gro'],
 #                wrapper_name='gmx'):
-def make_input(simulation_parameters='md.mdp',
-               topology='md.top',
-               conformation='md.gro',
-               wrapper_name=_gmx_cli_entry_point):
+def make_input(
+    simulation_parameters="md.mdp", topology="md.top", conformation="md.gro", wrapper_name=_gmx_cli_entry_point
+):
     preprocess = _executable(
         argv=(
             wrapper_name,
-            'grompp',
-            '-f', simulation_parameters,
-            '-p', topology,
-            '-c', conformation,
-            '-o', 'topol.tpr'
+            "grompp",
+            "-f",
+            simulation_parameters,
+            "-p",
+            topology,
+            "-c",
+            conformation,
+            "-o",
+            "topol.tpr",
         )
     )
     return {
-        'implementation': ['scalems', 'wrappers', 'gromacs', 'SimulationInput'],
-        'message': {
-            'SimulationInput': {'input': preprocess}
-        }
+        "implementation": ["scalems", "wrappers", "gromacs", "SimulationInput"],
+        "message": {"SimulationInput": {"input": preprocess}},
     }
 
 
 def simulate(arg, **kwargs):
-    if not isinstance(arg, dict) or 'SimulationInput' not in arg.get('message', ()):
-        raise TypeError('Bad input.')
-    simulator_input = arg['message']['SimulationInput']['input']
+    if not isinstance(arg, dict) or "SimulationInput" not in arg.get("message", ()):
+        raise TypeError("Bad input.")
+    simulator_input = arg["message"]["SimulationInput"]["input"]
     # Note: We haven't implemented modify_input or simulation chaining yet.
-    if not isinstance(simulator_input, dict) or 'implementation' not in simulator_input:
-        raise TypeError('Wrong kind of input object.')
+    if not isinstance(simulator_input, dict) or "implementation" not in simulator_input:
+        raise TypeError("Wrong kind of input object.")
     return {
-        'implementation': ['scalems', 'wrappers', 'gromacs', 'Simulate'],
-        'message': {
-            'Simulate': {'input': simulator_input, 'kwargs': kwargs}
-        }
+        "implementation": ["scalems", "wrappers", "gromacs", "Simulate"],
+        "message": {"Simulate": {"input": simulator_input, "kwargs": kwargs}},
     }
 
 
@@ -183,30 +177,34 @@ def scalems_helper(*args, **kwargs):
         here to allow the module author to provide information to the workflow manager
         or dispatch along different run time code paths according to the execution environment.
     """
-    logger.debug('scalems_helper called with args:({}), kwargs:({})'.format(
-        ','.join([repr(arg) for arg in args]),
-        ','.join([':'.join((key, repr(value))) for key, value in kwargs.items()])
-    ))
+    logger.debug(
+        "scalems_helper called with args:({}), kwargs:({})".format(
+            ",".join([repr(arg) for arg in args]),
+            ",".join([":".join((key, repr(value))) for key, value in kwargs.items()]),
+        )
+    )
 
 
 @scalems_helper.register
 def _(task: scalems.workflow.Task, context: WorkflowManager):
-    sublogger = logger.getChild('scalems_helper')
-    sublogger.debug('Serialized task record: {}'.format(task.serialize()))
+    sublogger = logger.getChild("scalems_helper")
+    sublogger.debug("Serialized task record: {}".format(task.serialize()))
     command = task.type[-1]
-    assert command in {'Simulate', 'SimulationInput', 'Executable'}
+    assert command in {"Simulate", "SimulationInput", "Executable"}
     # Right now, we should only need to process the 'Simulate' command...
-    assert command == 'Simulate'
+    assert command == "Simulate"
     # TODO: Typing on the Task data proxy.
-    command_message = task.input['message'][command]
+    command_message = task.input["message"][command]
     # kwargs = command_message['kwargs']
-    input_ref: str = command_message['input']
-    logger.debug(f'Decoding reference {input_ref}')
+    input_ref: str = command_message["input"]
+    logger.debug(f"Decoding reference {input_ref}")
     input_ref: bytes = bytes.fromhex(input_ref)
     task_map = context.task_map
-    logger.debug('Items done: {}'.format(
-        ', '.join([': '.join([key.hex(), str(value.done())]) for key, value in task_map.items()])
-    ))
+    logger.debug(
+        "Items done: {}".format(
+            ", ".join([": ".join([key.hex(), str(value.done())]) for key, value in task_map.items()])
+        )
+    )
     # simulator_input_view = context.item(input_ref)
 
     # TODO: Workaround until we have the framework deliver results.
@@ -214,8 +212,9 @@ def _(task: scalems.workflow.Task, context: WorkflowManager):
     # logger.debug(f'Acquired grompp output: {simulator_input}')
     # tprfile = simulator_input.file['-o']
     dependency_dir = pathlib.Path(os.getcwd()).parent / input_ref.hex()
-    tprfile = dependency_dir / 'topol.tpr'
+    tprfile = dependency_dir / "topol.tpr"
     import gmxapi
+
     md_in = gmxapi.read_tpr(str(tprfile))
     # TODO: Manage or integrate with gmxapi working directories.
     md = gmxapi.mdrun(md_in)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -17,7 +17,7 @@ from scalems.serialization import Shape
 from scalems.identifiers import TypeIdentifier
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 record = """{
     "version"= "scalems_workflow_1",
@@ -221,10 +221,8 @@ def test_shape():
 
 
 def test_resource_type():
-    scoped_name = ['scalems', 'subprocess', 'SubprocessTask']
-    description = scalems.workflow.Description(
-        resource_type=TypeIdentifier(tuple(scoped_name)),
-        shape=(1,))
+    scoped_name = ["scalems", "subprocess", "SubprocessTask"]
+    description = scalems.workflow.Description(resource_type=TypeIdentifier(tuple(scoped_name)), shape=(1,))
     assert description.type() == TypeIdentifier(tuple(scoped_name))
 
 
@@ -233,7 +231,7 @@ def test_encoding_str():
 
     Note: we may choose not to support bare strings through our serialization module.
     """
-    string = 'asdf'
+    string = "asdf"
     serialized = json.dumps(string, default=encode)
     round_trip = json.loads(serialized)
     assert string == round_trip
@@ -291,7 +289,7 @@ def test_encoding_int():
 
 def test_encoding_bytes():
     length = 8
-    data = (42).to_bytes(length=length, byteorder='big')
+    data = (42).to_bytes(length=length, byteorder="big")
     serialized = json.dumps(data, default=encode)
     round_trip = json.loads(serialized)
     # TODO: decoder
@@ -301,6 +299,7 @@ def test_encoding_bytes():
 
 def test_encoding_fileobject():
     import tempfile
+
     with tempfile.NamedTemporaryFile() as fh:
         filename = fh.name
         assert os.path.exists(filename)
@@ -316,22 +315,22 @@ def test_encoding_fileobject():
 def test_basic_decoding():
     # Let the basic encoder/decoder handle things that look like SCALE-MS objects.
     encoded = {
-        'label': None,
-        'identity': uuid.uuid4().hex,
-        'type': ['test', 'Spam'],
-        'shape': [1],
-        'data': ['spam', 'eggs', 'spam', 'spam']
+        "label": None,
+        "identity": uuid.uuid4().hex,
+        "type": ["test", "Spam"],
+        "shape": [1],
+        "data": ["spam", "eggs", "spam", "spam"],
     }
     instance = decode(encoded)
     assert type(instance) is BasicSerializable
     shape_ref = Shape((1,))
     assert instance.shape() == shape_ref
-    type_ref = TypeIdentifier(('test', 'Spam'))
+    type_ref = TypeIdentifier(("test", "Spam"))
     instance_type = instance.dtype()
     assert instance_type == type_ref
 
     # Test basic encoding, too.
-    assert tuple(instance.encode()['data']) == tuple(encoded['data'])
+    assert tuple(instance.encode()["data"]) == tuple(encoded["data"])
     assert instance.encode() == decode(instance.encode()).encode()
     # TODO: Check non-trivial shape.
 
@@ -342,15 +341,16 @@ def test_encoder_registration():
     ...
 
     # Test framework for type creation and automatic registration.
-    class SpamInstance(BasicSerializable, base_type=('test', 'Spam')):
+    class SpamInstance(BasicSerializable, base_type=("test", "Spam")):
         ...
 
-    instance = SpamInstance(label='my_spam',
-                            identity=uuid.uuid4().hex,
-                            dtype=['test', 'Spam'],
-                            shape=(1,),
-                            data=['spam', 'eggs', 'spam', 'spam']
-                            )
+    instance = SpamInstance(
+        label="my_spam",
+        identity=uuid.uuid4().hex,
+        dtype=["test", "Spam"],
+        shape=(1,),
+        data=["spam", "eggs", "spam", "spam"],
+    )
     assert not type(instance) is BasicSerializable
 
     encoded = encode(instance)
@@ -362,11 +362,12 @@ def test_encoder_registration():
     del decoded
     del SpamInstance
     import gc
+
     gc.collect()
     with pytest.raises(ProtocolError):
         decode(encoded)
 
-    decode.unregister(TypeIdentifier(('test', 'Spam')))
+    decode.unregister(TypeIdentifier(("test", "Spam")))
     decoded = decode(encoded)
     assert type(decoded) is BasicSerializable
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -9,19 +9,19 @@ import logging
 from scalems.messages import Command, StopCommand
 
 logger = logging.getLogger(__name__)
-logger.debug('Importing {}'.format(__name__))
+logger.debug("Importing {}".format(__name__))
 
 
 def test_serialization():
     cmd = StopCommand()
     serialized = json.dumps(cmd.encode())
     obj: dict = json.loads(serialized)
-    assert 'control' in obj.keys()
-    assert obj['control'] == 'stop'
+    assert "control" in obj.keys()
+    assert obj["control"] == "stop"
 
 
 def test_deserialization():
     serialized_stop = '{"control": "stop"}'
     cmd = Command.decode(json.loads(serialized_stop))
-    assert cmd.key == 'control'
-    assert cmd.message == 'stop'
+    assert cmd.key == "control"
+    assert cmd.message == "stop"

--- a/tests/test_radical_runtime.py
+++ b/tests/test_radical_runtime.py
@@ -12,12 +12,9 @@ from scalems.radical.runtime import Runtime
 def test_runtime_normal_instance(rp_task_manager, pilot_description):
     """Set the Runtime.pilot from an rp.Pilot instance."""
     with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.task_manager')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.db.database')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.session')
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
 
         session: rp.Session = rp_task_manager.session
 
@@ -30,8 +27,8 @@ def test_runtime_normal_instance(rp_task_manager, pilot_description):
         # We get a dictionary...
         # assert isinstance(pilot, rp.Pilot)
         # But it looks like it has the pilot id in it.
-        pilot_uid = typing.cast(dict, pilot)['uid']
-        pmgr_uid = typing.cast(dict, pilot)['pmgr']
+        pilot_uid = typing.cast(dict, pilot)["uid"]
+        pmgr_uid = typing.cast(dict, pilot)["pmgr"]
         pmgr: rp.PilotManager = session.get_pilot_managers(pmgr_uids=pmgr_uid)
         assert isinstance(pmgr, rp.PilotManager)
 
@@ -45,12 +42,9 @@ def test_runtime_normal_instance(rp_task_manager, pilot_description):
 def test_runtime_normal_uid(rp_task_manager, pilot_description):
     """Set the Runtime.pilot from the UID obtained from the task_manager."""
     with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.task_manager')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.db.database')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.session')
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
 
         session: rp.Session = rp_task_manager.session
 
@@ -63,13 +57,13 @@ def test_runtime_normal_uid(rp_task_manager, pilot_description):
         # We get a dictionary...
         # assert isinstance(pilot, rp.Pilot)
         # But it looks like it has the pilot id in it.
-        pilot_uid = typing.cast(dict, pilot)['uid']
+        pilot_uid = typing.cast(dict, pilot)["uid"]
 
         # It is an error to set a Pilot before the PilotManager has been set.
         with pytest.raises(APIError):
             state.pilot(pilot_uid)
 
-        pmgr_uid = typing.cast(dict, pilot)['pmgr']
+        pmgr_uid = typing.cast(dict, pilot)["pmgr"]
 
         state.pilot_manager(pmgr_uid)
 
@@ -78,12 +72,9 @@ def test_runtime_normal_uid(rp_task_manager, pilot_description):
 
 def test_runtime_bad_uid(pilot_description):
     with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.task_manager')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.db.database')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.session')
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
 
         session = rp.Session()
 
@@ -91,19 +82,19 @@ def test_runtime_bad_uid(pilot_description):
             state = Runtime(session=session)
 
             with pytest.raises(ValueError):
-                state.task_manager('spam')
+                state.task_manager("spam")
 
             tmgr = rp.TaskManager(session=session)
             state.task_manager(tmgr)
 
             with pytest.raises(ValueError):
-                state.pilot_manager('spam')
+                state.pilot_manager("spam")
 
             pmgr = rp.PilotManager(session=session)
             state.pilot_manager(pmgr)
 
             with pytest.raises(ValueError):
-                state.pilot_manager('spam')
+                state.pilot_manager("spam")
 
             tmgr.close()
             pmgr.close()
@@ -113,12 +104,9 @@ def test_runtime_bad_uid(pilot_description):
 
 def test_runtime_mismatch(pilot_description):
     with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.task_manager')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.db.database')
-        warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                module='radical.pilot.session')
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
 
         session = rp.Session()
 

--- a/tests/test_raptor_utilities.py
+++ b/tests/test_raptor_utilities.py
@@ -32,8 +32,7 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-pytestmark = pytest.mark.skipif(condition=rp is None,
-                                reason='These tests require RADICAL Pilot.')
+pytestmark = pytest.mark.skipif(condition=rp is None, reason="These tests require RADICAL Pilot.")
 
 client_scalems_version = packaging.version.Version(scalems.__version__)
 if client_scalems_version.is_prerelease:
@@ -56,43 +55,35 @@ def test_master_configuration_details(rp_venv):
     gpus_per_process = 0
 
     # TODO: Add additional dependencies that we can infer from the workflow.
-    versioned_modules = (
-        ('scalems', minimum_scalems_version),
-        ('radical.pilot', rp.version_short)
-    )
+    versioned_modules = (("scalems", minimum_scalems_version), ("radical.pilot", rp.version_short))
 
     # Note that the Worker launch has unspecified results if the `named_env`
     # does not exist and is not scheduled to be created with `prepare_env`.
     # However, we are not currently using `named_env`. See #90.
     configuration = MasterTaskConfiguration(
         worker=ClientWorkerRequirements(
-            named_env='scalems_test_ve',
-            pre_exec=[],
-            cpu_processes=worker_processes,
-            gpus_per_process=gpus_per_process
+            named_env="scalems_test_ve", pre_exec=[], cpu_processes=worker_processes, gpus_per_process=gpus_per_process
         ),
-        versioned_modules=list(versioned_modules)
+        versioned_modules=list(versioned_modules),
     )
     # Note: *named_env* is unused, pending work on #90 and others.
 
     conf_dict: scalems.radical.raptor._MasterTaskConfigurationDict = dataclasses.asdict(configuration)
     configuration = MasterTaskConfiguration.from_dict(conf_dict)
     assert configuration.versioned_modules == list(versioned_modules)
-    assert configuration.worker.named_env == 'scalems_test_ve'
+    assert configuration.worker.named_env == "scalems_test_ve"
 
     encoded = json.dumps(configuration, default=object_encoder, indent=2)
-    configuration = scalems.radical.raptor.MasterTaskConfiguration.from_dict(
-        json.loads(encoded)
-    )
+    configuration = scalems.radical.raptor.MasterTaskConfiguration.from_dict(json.loads(encoded))
     assert configuration.versioned_modules == [list(module_spec) for module_spec in versioned_modules]
-    assert configuration.worker.named_env == 'scalems_test_ve'
+    assert configuration.worker.named_env == "scalems_test_ve"
 
-    with pytest.warns(match='raptor.Master base class'):
+    with pytest.warns(match="raptor.Master base class"):
         master = ScaleMSMaster(configuration)
     with master.configure_worker(configuration.worker) as worker_config:
-        assert worker_config['count'] == num_workers
-        descr: WorkerDescriptionDict = worker_config['descr']
-        assert descr['ranks'] == worker_processes
-        assert descr['worker_class'] == ScaleMSWorker.__name__
-        assert os.path.exists(descr['worker_file'])
-    assert not os.path.exists(descr['worker_file'])
+        assert worker_config["count"] == num_workers
+        descr: WorkerDescriptionDict = worker_config["descr"]
+        assert descr["ranks"] == worker_processes
+        assert descr["worker_class"] == ScaleMSWorker.__name__
+        assert os.path.exists(descr["worker_file"])
+    assert not os.path.exists(descr["worker_file"])

--- a/tests/test_rp_basic.py
+++ b/tests/test_rp_basic.py
@@ -12,21 +12,23 @@ logger.setLevel(logging.DEBUG)
 
 
 def seems_local(pilot_description):
-    if (pilot_description.access_schema and pilot_description.access_schema == 'local') \
-            or 'local' in pilot_description.resource \
-            or pilot_description.resource == 'docker.login':
+    if (
+        (pilot_description.access_schema and pilot_description.access_schema == "local")
+        or "local" in pilot_description.resource
+        or pilot_description.resource == "docker.login"
+    ):
         return True
 
 
 def test_rp_basic_task_local(rp_task_manager, pilot_description):
     if not seems_local(pilot_description):
-        pytest.skip('This test is only for local execution.')
+        pytest.skip("This test is only for local execution.")
 
     from radical.pilot import TaskDescription
+
     tmgr = rp_task_manager
 
-    td = TaskDescription({'executable': '/bin/date',
-                          'cpu_processes': 1})
+    td = TaskDescription({"executable": "/bin/date", "cpu_processes": 1})
     task = tmgr.submit_tasks(td)
     tmgr.wait_tasks(uids=[task.uid])
 
@@ -37,14 +39,13 @@ def test_rp_basic_task_remote(rp_task_manager, pilot_description):
     import radical.pilot as rp
 
     if seems_local(pilot_description):
-        pytest.skip('This test is only for remote execution.')
+        pytest.skip("This test is only for remote execution.")
 
     tmgr = rp_task_manager
     session = tmgr.session
     assert not session.closed
 
-    td = rp.TaskDescription({'executable': '/usr/bin/hostname',
-                             'cpu_processes': 1})
+    td = rp.TaskDescription({"executable": "/usr/bin/hostname", "cpu_processes": 1})
 
     task = tmgr.submit_tasks(td)
 
@@ -53,7 +54,7 @@ def test_rp_basic_task_remote(rp_task_manager, pilot_description):
     assert task.state == rp.states.DONE
     assert task.exit_code == 0
 
-    localname = subprocess.run(['/usr/bin/hostname'], stdout=subprocess.PIPE, encoding='utf-8').stdout.rstrip()
+    localname = subprocess.run(["/usr/bin/hostname"], stdout=subprocess.PIPE, encoding="utf-8").stdout.rstrip()
     remotename = task.stdout.rstrip()
     assert len(remotename) > 0
     assert remotename != localname

--- a/tests/test_rp_future.py
+++ b/tests/test_rp_future.py
@@ -32,11 +32,9 @@ async def test_rp_future(rp_task_manager):
 
     tmgr = rp_task_manager
 
-    td = rp.TaskDescription({
-                                'executable': '/bin/bash',
-                                'arguments': ['-c', '/bin/sleep 5 && /bin/echo success'],
-                                'cpu_processes': 1
-                            })
+    td = rp.TaskDescription(
+        {"executable": "/bin/bash", "arguments": ["-c", "/bin/sleep 5 && /bin/echo success"], "cpu_processes": 1}
+    )
 
     # Test propagation of RP cancellation behavior
     task: rp.Task = tmgr.submit_tasks(td)
@@ -73,12 +71,12 @@ async def test_rp_future(rp_task_manager):
 
     # WARNING: rp.Task.wait blocks, and may never complete. Don't do it in the event loop thread.
     to_thread = scalems.utility.get_to_thread()
-    watcher = asyncio.create_task(to_thread(task.wait), name=f'watch_{task.uid}')
+    watcher = asyncio.create_task(to_thread(task.wait), name=f"watch_{task.uid}")
     try:
         state = await asyncio.wait_for(watcher, timeout=timeout)
     except asyncio.TimeoutError as e:
-        logger.exception(f'Waited more than {timeout} for {watcher}')
-        watcher.cancel('Canceled after waiting too long.')
+        logger.exception(f"Waited more than {timeout} for {watcher}")
+        watcher.cancel("Canceled after waiting too long.")
         raise e
     else:
         assert state in rp.states.FINAL
@@ -89,11 +87,11 @@ async def test_rp_future(rp_task_manager):
     assert task.state in (rp.states.CANCELED,)
 
     # Test run to completion
-    watcher = asyncio.create_task(to_thread(tmgr.submit_tasks, td), name='rp_submit')
+    watcher = asyncio.create_task(to_thread(tmgr.submit_tasks, td), name="rp_submit")
     try:
         task: rp.Task = await asyncio.wait_for(watcher, timeout=timeout)
     except asyncio.TimeoutError as e:
-        logger.exception(f'Waited more than {timeout} to submit {td}.')
+        logger.exception(f"Waited more than {timeout} to submit {td}.")
         watcher.cancel()
         raise e
 
@@ -101,21 +99,21 @@ async def test_rp_future(rp_task_manager):
     try:
         result: rp.Task = await asyncio.wait_for(rp_future, timeout=timeout)
     except asyncio.TimeoutError as e:
-        logger.debug(f'Waited more than {timeout} for {rp_future}: {e}')
-        rp_future.cancel('Canceled after waiting too long.')
+        logger.debug(f"Waited more than {timeout} for {rp_future}: {e}")
+        rp_future.cancel("Canceled after waiting too long.")
         raise e
     assert task.exit_code == 0
-    assert 'success' in task.stdout
+    assert "success" in task.stdout
 
-    assert hasattr(result, 'stdout')
-    assert 'success' in result.stdout
+    assert hasattr(result, "stdout")
+    assert "success" in result.stdout
     assert rp_future.done()
 
     # Test failure handling
     # TODO: Use a separate test for results and error handling.
 
 
-@pytest.mark.skip(reason='Unimplemented.')
+@pytest.mark.skip(reason="Unimplemented.")
 @pytest.mark.asyncio
 async def test_chained_commands():
     """Run a sequence of two tasks with a data flow dependency."""

--- a/tests/test_rp_venv.py
+++ b/tests/test_rp_venv.py
@@ -21,15 +21,15 @@ def test_register_venv(cleandir, rp_task_manager, rp_venv):
     import radical.pilot as rp
     import radical.utils as ru
 
-    logger.debug(f'Client RP version is {rp.version}.')
+    logger.debug(f"Client RP version is {rp.version}.")
 
     # We only expect one pilot
     pilot: rp.Pilot = rp_task_manager.get_pilots()[0]
     # We get a dictionary...
     # assert isinstance(pilot, rp.Pilot)
     # But it looks like it has the pilot id in it.
-    pilot_uid = typing.cast(dict, pilot)['uid']
-    pmgr_uid = typing.cast(dict, pilot)['pmgr']
+    pilot_uid = typing.cast(dict, pilot)["uid"]
+    pmgr_uid = typing.cast(dict, pilot)["pmgr"]
     session: rp.Session = rp_task_manager.session
     pmgr: rp.PilotManager = session.get_pilot_managers(pmgr_uids=pmgr_uid)
     assert isinstance(pmgr, rp.PilotManager)
@@ -38,108 +38,85 @@ def test_register_venv(cleandir, rp_task_manager, rp_venv):
     # It looks like either the pytest fixture should deliver something other than the TaskManager,
     # or the prepare_venv part should be moved to a separate function, such as in conftest...
 
-    access = pilot.description['access_schema']
-    if access not in ('local', 'ssh'):
+    access = pilot.description["access_schema"]
+    if access not in ("local", "ssh"):
         pytest.skip('This test only understands "local" and "ssh" RP access schema.')
 
     # We use a (user-specified) venv for the Pilot agent.
-    executable = os.path.join(rp_venv, 'bin', 'python3')
+    executable = os.path.join(rp_venv, "bin", "python3")
 
     # Create a temporary venv for this test.
-    env_name = 'test-env'
-    env_path = '/tmp/test_env'
+    env_name = "test-env"
+    env_path = "/tmp/test_env"
 
-    scriptlet = f'test -d {env_path} && rm -rf {env_path} || true '
-    scriptlet += f'; {executable} -m venv {env_path} '
-    scriptlet += f'; . {env_path}/bin/activate '
-    scriptlet += '; python -m pip install --upgrade pip setuptools wheel '
-    scriptlet += f'; pip install radical.pilot=={rp.version}'
-    command = [
-        'bash',
-        '-c',
-        scriptlet]
+    scriptlet = f"test -d {env_path} && rm -rf {env_path} || true "
+    scriptlet += f"; {executable} -m venv {env_path} "
+    scriptlet += f"; . {env_path}/bin/activate "
+    scriptlet += "; python -m pip install --upgrade pip setuptools wheel "
+    scriptlet += f"; pip install radical.pilot=={rp.version}"
+    command = ["bash", "-c", scriptlet]
 
-    if access == 'local':
-        process = subprocess.run(
-            args=command,
-            capture_output=True,
-            check=True,
-            text=True,
-            shell=False
-        )
+    if access == "local":
+        process = subprocess.run(args=command, capture_output=True, check=True, text=True, shell=False)
     else:
         # We don't have automated handling for other access methods at this time.
-        assert access == 'ssh'
+        assert access == "ssh"
 
-        domain, target = str(pilot.resource).split('.')
-        resource_config = ru.Config(
-            module='radical.pilot.resource',
-            name=domain)[target]
-        ssh_target = resource_config[access]['job_manager_endpoint']
+        domain, target = str(pilot.resource).split(".")
+        resource_config = ru.Config(module="radical.pilot.resource", name=domain)[target]
+        ssh_target = resource_config[access]["job_manager_endpoint"]
         result: ParseResult = urlparse(ssh_target)
-        assert result.scheme == 'ssh'
+        assert result.scheme == "ssh"
         user = result.username
         port = result.port
         host = result.hostname
 
-        ssh = [shutil.which('ssh')]
+        ssh = [shutil.which("ssh")]
         if user:
-            ssh.extend(['-l', user])
+            ssh.extend(["-l", user])
         if port:
-            ssh.extend(['-p', str(port)])
+            ssh.extend(["-p", str(port)])
         ssh.append(host)
 
         command = [shlex.quote(arg) for arg in command]
-        logger.debug(f'Executing subprocess {ssh + command}')
+        logger.debug(f"Executing subprocess {ssh + command}")
         process = subprocess.run(
-            ssh + command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=180,
-            encoding='utf-8',
-            shell=False
+            ssh + command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=180, encoding="utf-8", shell=False
         )
         if process.returncode != 0:
-            logger.error('Failed ssh stdout: ' + str(process.stdout))
-            logger.error('Failed ssh stderr: ' + str(process.stderr))
+            logger.error("Failed ssh stdout: " + str(process.stdout))
+            logger.error("Failed ssh stderr: " + str(process.stderr))
 
-    logger.debug(f'stdout: {process.stdout}')
+    logger.debug(f"stdout: {process.stdout}")
     if process.stderr:
-        logger.error(f'stderr: {process.stderr}')
+        logger.error(f"stderr: {process.stderr}")
     assert process.returncode == 0
 
     # Use the client-managed venv in a rp.Task with `named_env`
     # Register venv
-    pilot.prepare_env(
-        env_name=env_name,
-        env_spec={
-            'type': 'venv',
-            'path': env_path,
-            'setup': []
-        }
-    )
+    pilot.prepare_env(env_name=env_name, env_spec={"type": "venv", "path": env_path, "setup": []})
 
     # Use the registered venv.
     td = {
-        'executable': 'python',
-        'arguments': ['-c', 'import sys; print(sys.executable)'],
-        'named_env': env_name,
-        'pre_exec': [],
-        'stage_on_error': True,
+        "executable": "python",
+        "arguments": ["-c", "import sys; print(sys.executable)"],
+        "named_env": env_name,
+        "pre_exec": [],
+        "stage_on_error": True,
     }
 
     task = rp_task_manager.submit_tasks(rp.TaskDescription(td))
     task.wait(state=[rp.states.AGENT_EXECUTING] + rp.FINAL, timeout=120)
-    logger.info(f'state is {task.state}.')
-    logger.debug(f'stdout: {task.stdout}')
+    logger.info(f"state is {task.state}.")
+    logger.debug(f"stdout: {task.stdout}")
     if task.stderr:
-        logger.error(f'stderr: {task.stderr}')
+        logger.error(f"stderr: {task.stderr}")
     assert task.exit_code == 0
     # Confirm we used the venv we think we used.
-    assert env_path + '/bin/python' in task.stdout
+    assert env_path + "/bin/python" in task.stdout
 
 
-@pytest.mark.skip(reason='Currently unused.')
+@pytest.mark.skip(reason="Currently unused.")
 def test_prepare_venv(rp_task_manager, sdist, rp_venv):
     """Bootstrap the scalems package in a RP target environment using pilot.prepare_env.
 
@@ -151,13 +128,14 @@ def test_prepare_venv(rp_task_manager, sdist, rp_venv):
     import radical.pilot as rp
     import radical.saga as rs
     import radical.utils as ru
+
     # We only expect one pilot
     pilot: rp.Pilot = rp_task_manager.get_pilots()[0]
     # We get a dictionary...
     # assert isinstance(pilot, rp.Pilot)
     # But it looks like it has the pilot id in it.
-    pilot_uid = typing.cast(dict, pilot)['uid']
-    pmgr_uid = typing.cast(dict, pilot)['pmgr']
+    pilot_uid = typing.cast(dict, pilot)["uid"]
+    pmgr_uid = typing.cast(dict, pilot)["pmgr"]
     session: rp.Session = rp_task_manager.session
     pmgr: rp.PilotManager = session.get_pilot_managers(pmgr_uids=pmgr_uid)
     assert isinstance(pmgr, rp.PilotManager)
@@ -167,18 +145,13 @@ def test_prepare_venv(rp_task_manager, sdist, rp_venv):
     # or the prepare_venv part should be moved to a separate function, such as in conftest...
 
     sdist_names = {
-        'ru': ru.sdist_name,
-        'rs': rs.sdist_name,
-        'rp': rp.sdist_name,
-        'scalems': os.path.basename(sdist),
+        "ru": ru.sdist_name,
+        "rs": rs.sdist_name,
+        "rp": rp.sdist_name,
+        "scalems": os.path.basename(sdist),
     }
-    sdist_local_paths = {
-        'scalems': sdist,
-        'rp': rp.sdist_path,
-        'rs': rs.sdist_path,
-        'ru': ru.sdist_path
-    }
-    logger.debug('Checking paths: ' + ', '.join(sdist_local_paths.values()))
+    sdist_local_paths = {"scalems": sdist, "rp": rp.sdist_path, "rs": rs.sdist_path, "ru": ru.sdist_path}
+    logger.debug("Checking paths: " + ", ".join(sdist_local_paths.values()))
     for path in sdist_local_paths.values():
         assert os.path.exists(path)
 
@@ -186,128 +159,95 @@ def test_prepare_venv(rp_task_manager, sdist, rp_venv):
 
     sdist_session_paths = {name: os.path.join(sandbox_path, sdist_names[name]) for name in sdist_names.keys()}
 
-    logger.debug('Staging ' + ', '.join(sdist_session_paths.values()))
+    logger.debug("Staging " + ", ".join(sdist_session_paths.values()))
 
     input_staging = []
     for name in sdist_names.keys():
-        input_staging.append({
-            'source': sdist_local_paths[name],
-            'target': sdist_names[name],
-            'action': rp.TRANSFER
-        })
+        input_staging.append({"source": sdist_local_paths[name], "target": sdist_names[name], "action": rp.TRANSFER})
     logger.debug(str(input_staging))
     pilot.stage_in(input_staging)
 
     tmgr = rp_task_manager
 
-    packages = [
-        'pip',
-        'setuptools',
-        'wheel']
+    packages = ["pip", "setuptools", "wheel"]
     packages.extend(sdist_session_paths.values())
 
     # We test in multiple environments, so we have to check what Python
     # interpreter is installed in the current target resource.
     # Note that, at this time, we use a single (user-specified) venv for the
     # Pilot agent and for the tasks.
-    executable = os.path.join(rp_venv, 'bin', 'python3')
+    executable = os.path.join(rp_venv, "bin", "python3")
     scriptlet = 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'
-    access = pilot.description['access_schema']
-    if access == 'local':
-        command = [
-            executable,
-            '-c',
-            scriptlet]
-        process = subprocess.run(
-            args=command,
-            capture_output=True,
-            check=True,
-            text=True
-        )
+    access = pilot.description["access_schema"]
+    if access == "local":
+        command = [executable, "-c", scriptlet]
+        process = subprocess.run(args=command, capture_output=True, check=True, text=True)
     else:
         # We don't have automated handling for other access methods at this time.
-        assert access == 'ssh'
+        assert access == "ssh"
 
-        domain, target = str(pilot.resource).split('.')
-        resource_config = ru.Config(
-            module='radical.pilot.resource',
-            name=domain)[target]
-        ssh_target = resource_config[access]['job_manager_endpoint']
+        domain, target = str(pilot.resource).split(".")
+        resource_config = ru.Config(module="radical.pilot.resource", name=domain)[target]
+        ssh_target = resource_config[access]["job_manager_endpoint"]
         result: ParseResult = urlparse(ssh_target)
-        assert result.scheme == 'ssh'
+        assert result.scheme == "ssh"
         user = result.username
         port = result.port
         host = result.hostname
 
-        ssh = [shutil.which('ssh')]
+        ssh = [shutil.which("ssh")]
         if user:
-            ssh.extend(['-l', user])
+            ssh.extend(["-l", user])
         if port:
-            ssh.extend(['-p', str(port)])
+            ssh.extend(["-p", str(port)])
         ssh.append(host)
 
-        command = [
-            executable,
-            '-c',
-            shlex.quote(scriptlet)]
+        command = [executable, "-c", shlex.quote(scriptlet)]
 
-        logger.debug(f'Executing subprocess {ssh + command}')
+        logger.debug(f"Executing subprocess {ssh + command}")
         process = subprocess.run(
-            ssh + command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=5,
-            encoding='utf-8')
+            ssh + command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, encoding="utf-8"
+        )
         if process.returncode != 0:
-            logger.error('Failed ssh stdout: ' + str(process.stdout))
-            logger.error('Failed ssh stderr: ' + str(process.stderr))
+            logger.error("Failed ssh stdout: " + str(process.stdout))
+            logger.error("Failed ssh stderr: " + str(process.stderr))
 
     assert process.returncode == 0
     python_version = process.stdout.rstrip()
-    logger.debug(f'Requesting Python version {python_version}.')
-    pilot.prepare_env(env_name='scalems_env',
-                      env_spec={
-                          'type': 'virtualenv',
-                          'version': python_version,
-                          'setup': packages
-                      })
+    logger.debug(f"Requesting Python version {python_version}.")
+    pilot.prepare_env(
+        env_name="scalems_env", env_spec={"type": "virtualenv", "version": python_version, "setup": packages}
+    )
 
     rp_check_desc = rp.TaskDescription(
         {
-            'executable': 'python3',
-            'arguments': [
-                '-c',
-                'import radical.pilot as rp; print(rp.version_detail)'
-            ],
-            'named_env': 'scalems_env'
+            "executable": "python3",
+            "arguments": ["-c", "import radical.pilot as rp; print(rp.version_detail)"],
+            "named_env": "scalems_env",
         }
     )
     scalems_check_desc = rp.TaskDescription(
         {
-            'executable': 'python3',
-            'arguments': [
-                '-c',
-                'import scalems; print(scalems.__file__)'
-            ],
-            'named_env': 'scalems_env'
+            "executable": "python3",
+            "arguments": ["-c", "import scalems; print(scalems.__file__)"],
+            "named_env": "scalems_env",
         }
     )
 
-    rp_check_task, scalems_check_task = \
-        tmgr.submit_tasks([rp_check_desc, scalems_check_desc])
+    rp_check_task, scalems_check_task = tmgr.submit_tasks([rp_check_desc, scalems_check_desc])
     tmgr.wait_tasks()
 
     rp_version = rp_check_task.stdout.rstrip()
     rp_version = packaging.version.parse(rp_version)
     if rp_check_task.stdout:
-        logger.debug(f'RP version details: {rp_version}')
+        logger.debug(f"RP version details: {rp_version}")
     if rp_check_task.stderr:
-        logger.debug(f'Task stderr: {rp_check_task.stderr}')
+        logger.debug(f"Task stderr: {rp_check_task.stderr}")
     assert rp_version == packaging.version.parse(rp.version)
     assert rp_check_task.exit_code == 0
 
     if scalems_check_task.stdout:
-        logger.debug(f'scalems package module: {scalems_check_task.stdout}')
+        logger.debug(f"scalems package module: {scalems_check_task.stdout}")
     if scalems_check_task.stderr:
-        logger.debug(f'Task stderr: {scalems_check_task.stderr}')
+        logger.debug(f"Task stderr: {scalems_check_task.stderr}")
     assert scalems_check_task.exit_code == 0

--- a/tests/test_subprocess_exec.py
+++ b/tests/test_subprocess_exec.py
@@ -26,7 +26,7 @@ async def test_exec_local(cleandir):
     with scalems.workflow.scope(context):
         # TODO: Input type checking.
         try:
-            cmd = executable(('/bin/cat', '-'), stdin=('hi there\n', 'hello world'), stdout='stdout.txt')
+            cmd = executable(("/bin/cat", "-"), stdin=("hi there\n", "hello world"), stdout="stdout.txt")
         except Exception as e:
             raise e
         assert isinstance(cmd, scalems.workflow.ItemView)
@@ -39,9 +39,9 @@ async def test_exec_local(cleandir):
         async with context.dispatch():
             ...
         result = cmd.result()  # type: scalems.subprocess.SubprocessResult
-        assert result.stdout.name == 'stdout.txt'
+        assert result.stdout.name == "stdout.txt"
         with open(result.stdout) as fh:
-            assert fh.read().startswith('hi there')
+            assert fh.read().startswith("hi there")
     # We need to close the filestore before we begin to initialize a new
     # WorkflowManager so that we don't try to take over an actively managed filestore.
     context.close()
@@ -52,12 +52,12 @@ async def test_exec_local(cleandir):
         # scalems.run(cmd)
         async with context.dispatch():
             # TODO: Input type checking.
-            cmd = executable(('/bin/echo', 'hello', 'world'), stdout='stdout.txt')
+            cmd = executable(("/bin/echo", "hello", "world"), stdout="stdout.txt")
             assert isinstance(cmd, scalems.workflow.ItemView)
         result = cmd.result()  # type: scalems.subprocess.SubprocessResult
-        assert result.stdout.name == 'stdout.txt'
+        assert result.stdout.name == "stdout.txt"
         with open(result.stdout) as fh:
-            assert fh.read().startswith('hello world')
+            assert fh.read().startswith("hello world")
     # We need to close the filestore before removing the temporary directory to avoid
     # errors.
     context.close()


### PR DESCRIPTION
I got tired of disagreements between `flake8` and my editor. I installed `black[d]` and applied Black formatting to the `src` and `tests` directories.

Strict Black style is not required by the automated lint checks at this time, because `flake8` is an effective weaker check.

Note that `black` attempts to be as reproducible as possible, so many lines were widened, in accordance with our 120 character limit previously adopted. We may want to narrow that limit at some point, but I have deferred such a decision from the present change.