### PR TITLE
Update required RCT versions.

### DIFF
--- a/docker/radicalpilot.dockerfile
+++ b/docker/radicalpilot.dockerfile
@@ -124,7 +124,7 @@ RUN mkdir /tmp/scalems_dev
 #    pip install --no-cache-dir --no-build-isolation --upgrade "git+https://github.com/radical-cybertools/radical.pilot.git@${RPREF}#egg=radical.pilot"
 #RUN ~rp/rp-venv/bin/python -m pip install \
 #    --no-cache-dir --no-build-isolation --upgrade "git+https://github.com/radical-cybertools/radical.pilot.git@scalems/stable#egg=radical.pilot"
-RUN ~rp/rp-venv/bin/python -m pip install 'radical.pilot>=1.18'
+RUN ~rp/rp-venv/bin/python -m pip install 'radical.pilot>=1.20'
 
 # WARNING!!! Security risk!
 # Allow rp user to trivially ssh into containers created from this image.

--- a/docker/rp-complete.dockerfile
+++ b/docker/rp-complete.dockerfile
@@ -83,7 +83,7 @@ RUN $RPVENV/bin/pip install --upgrade \
 # Get repository for example and test files and to simplify RPREF build argument.
 # Note that GitHub may have a source directory name suffix that does not exactly
 # match the branch or tag name, so we use a glob to try to normalize the name.
-ARG RPREF="v1.18.0"
+ARG RPREF="v1.20.0"
 #ARG RPREF="project/scalems"
 # Note: radical.pilot does not work properly with an "editable install"
 RUN git clone -b $RPREF --depth=3 https://github.com/radical-cybertools/radical.pilot.git && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "mpi4py",
     "packaging",
-    "radical.pilot >= 1.18"
+    "radical.pilot >= 1.20"
 ]
 
 [project.urls]
@@ -30,7 +30,7 @@ test = [
     "pytest >= 6.1.2 ",
     "pytest-asyncio >= 0.14",
     "pytest-env",
-    "radical.pilot >= 1.18"
+    "radical.pilot >= 1.20"
 ]
 
 [project.scripts]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -15,7 +15,7 @@ ntplib
 pylint
 pymongo<4.0
 python-hostlist
-radical.pilot>=1.18
+radical.pilot>=1.20
 setproctitle
 tox>=2.0
 # Raptor MPI worker requirements

--- a/src/scalems/radical/raptor.py
+++ b/src/scalems/radical/raptor.py
@@ -1561,14 +1561,6 @@ class TaskDictionary(typing.TypedDict):
     description: _RaptorTaskDescription
     """Encoding of the original task description."""
 
-    error: str
-    """Stack trace. Deprecated.
-
-    To be removed in radical.pilot>=1.19.0, replaced with `exception_detail`.
-
-    See https://github.com/SCALE-MS/scale-ms/discussions/259#discussioncomment-4095650
-    """
-
     stdout: str
     """Task standard output."""
 
@@ -1584,13 +1576,11 @@ class TaskDictionary(typing.TypedDict):
     Refer to the :py:class:`RaptorTaskExecutor` Protocol.
     """
 
-    exception: typing.Tuple[str, str]
-    """Exception type name and message.
+    exception: str
+    """Exception type name and message."""
 
-    TODO(radical.pilot>=1.19.0): The type of this field is changing to `str`.
-
-    Ref https://github.com/SCALE-MS/scale-ms/discussions/267
-    """
+    exception_detail: str
+    """Full exception details with stack trace."""
 
     state: str
     """RADICAL Pilot Task state."""

--- a/src/scalems/radical/raptor.py
+++ b/src/scalems/radical/raptor.py
@@ -342,7 +342,7 @@ arguments to raptor :py:data:`~radical.pilot.TASK_FUNCTION` mode executor.
 CPI_MESSAGE = "scalems.cpi"
 """Flag for scalems messages to be treated as CPI calls.
 
-Used in the :py:attr:`rp.TaskDescription.mode` field to indicate that the
+Used in the :py:attr:`~radical.pilot.TaskDescription.mode` field to indicate that the
 object should be handled through the SCALEMS Compute Provider Interface machinery.
 """
 

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -79,21 +79,13 @@ async def test_raptor_master(pilot_description, rp_venv, cleandir):
 
             # Bypass the scalems machinery and submit an instruction directly to the master task.
             scheduler: rp.Task = dispatcher.runtime.scheduler
-            td = rp.TaskDescription()
-            td.scheduler = scheduler.uid
-            td.mode = scalems.radical.raptor.CPI_MESSAGE
-            td.metadata = scalems.messages.HelloCommand().encode()
-            # TODO: The dictionary-based initialization should be working again
-            # with radical.utils > 1.18.1.
-            # See https://github.com/radical-cybertools/radical.utils/pull/367.
-            # Ref https://github.com/radical-cybertools/radical.pilot/issues/2797
-            #     td = rp.TaskDescription(
-            #         from_dict={
-            #             'scheduler': scheduler.uid,
-            #             'mode': scalems.radical.raptor.CPI_MESSAGE,
-            #             'metadata': scalems.messages.HelloCommand().encode()
-            #         }
-            #     )
+            td = rp.TaskDescription(
+                from_dict={
+                    'scheduler': scheduler.uid,
+                    'mode': scalems.radical.raptor.CPI_MESSAGE,
+                    'metadata': scalems.messages.HelloCommand().encode()
+                }
+            )
             logger.debug(f"Submitting {str(td.as_dict())}")
             tasks = await to_thread(dispatcher.runtime.task_manager().submit_tasks, [td])
             hello_task = tasks[0]

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -9,6 +9,7 @@ Note: ``export RADICAL_LOG_LVL=DEBUG`` to enable RP debugging output.
 """
 
 import asyncio
+import dataclasses
 import json
 import os
 
@@ -110,7 +111,7 @@ async def test_raptor_master(pilot_description, rp_venv, cleandir):
     assert state == rp.DONE
     assert hello_task.stdout == repr(scalems.radical.raptor.backend_version)
     # Ref https://github.com/SCALE-MS/scale-ms/discussions/268
-    # assert task.return_value == scalems.__version__
+    assert hello_task.return_value == dataclasses.asdict(scalems.radical.raptor.backend_version)
 
     # Note: As we refine the dispatching protocol, make sure we don't wait for STOP controls to finish.
     #     state = await asyncio.wait_for(stop_watcher, timeout=120)

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -9,7 +9,6 @@ Note: ``export RADICAL_LOG_LVL=DEBUG`` to enable RP debugging output.
 """
 
 import asyncio
-import dataclasses
 import json
 import os
 
@@ -111,7 +110,7 @@ async def test_raptor_master(pilot_description, rp_venv, cleandir):
     assert state == rp.DONE
     assert hello_task.stdout == repr(scalems.radical.raptor.backend_version)
     # Ref https://github.com/SCALE-MS/scale-ms/discussions/268
-    assert hello_task.return_value == dataclasses.asdict(scalems.radical.raptor.backend_version)
+    # assert task.return_value == scalems.__version__
 
     # Note: As we refine the dispatching protocol, make sure we don't wait for STOP controls to finish.
     #     state = await asyncio.wait_for(stop_watcher, timeout=120)

--- a/tests/test_rp_future.py
+++ b/tests/test_rp_future.py
@@ -76,7 +76,11 @@ async def test_rp_future(rp_task_manager):
         state = await asyncio.wait_for(watcher, timeout=timeout)
     except asyncio.TimeoutError as e:
         logger.exception(f"Waited more than {timeout} for {watcher}")
-        watcher.cancel("Canceled after waiting too long.")
+        try:
+            watcher.cancel("Canceled after waiting too long.")
+        except TypeError:
+            # the *msg* argument was added to Task.cancel in Py 3.9.
+            watcher.cancel()
         raise e
     else:
         assert state in rp.states.FINAL


### PR DESCRIPTION
Several bug fixes and at least one schema change make RP 1.20 an appropriate minimum requirement before proceeding further with scalems development.