### PR TITLE
Minor tidying

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -22,6 +22,7 @@ Protocols
 
 .. automodule:: scalems.file
     :members:
+    :exclude-members: DataLocalizationError
 
 Data store
 ----------

--- a/docs/executor_radical.rst
+++ b/docs/executor_radical.rst
@@ -39,6 +39,7 @@ scalems.radical.raptor
 ----------------------
 
 .. automodule:: scalems.radical.raptor
+    :no-members:
 
 master task
 ~~~~~~~~~~~

--- a/docs/invocation.rst
+++ b/docs/invocation.rst
@@ -62,10 +62,13 @@ scalems.radical Python module
 -----------------------------
 
 .. automodule:: scalems.radical
+    :no-members:
 
 .. _scalems.radical command line:
 
 .. autoprogram:: scalems.radical:parser
+
+.. seealso:: :doc:`executor_radical`
 
 .. _venvs:
 

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -214,18 +214,7 @@ Base classes
                                   simulation=initial_input)
         loop.run()
 
-.. I list the members explicitly because nothing else seems to suppress the documentation of __fspath__ in Sphinx 4.1.2
-.. autoclass:: scalems.file.AbstractFileReference
-    :members: is_local, path, as_uri, localize
-    :noindex:
-
-.. autoclass:: scalems.file.BaseBinary
-    :members:
-    :noindex:
-
-.. autoclass:: scalems.file.BaseText
-    :members:
-    :noindex:
+.. seealso:: :doc:`data`
 
 Logging
 =======

--- a/src/scalems/radical/raptor/__init__.py
+++ b/src/scalems/radical/raptor/__init__.py
@@ -248,6 +248,22 @@ See https://github.com/radical-cybertools/radical.pilot/issues/2731
 """
 from __future__ import annotations
 
+__all__ = (
+    "ClientWorkerRequirements",
+    "MasterTaskConfiguration",
+    "master_script",
+    "master_input",
+    "master",
+    "worker_requirements",
+    "worker_description",
+    "SoftwareCompatibilityError",
+    "ScaleMSWorker",
+    "ScaleMSMaster",
+    "ScalemsRaptorWorkItem",
+    "WorkerDescriptionDict",
+    "RaptorWorkerConfig",
+)
+
 import abc
 import argparse
 import asyncio

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -277,6 +277,10 @@ class Configuration:
 class Runtime:
     """Container for scalems.radical runtime state data.
 
+    Note:
+        This class is almost exclusively a container. Lifetime management is assumed
+        to be handled externally.
+
     .. todo:: Consider either merging with `scalems.radical.runtime.Configuration` or
         explicitly encapsulating the responsibilities of `RPDispatchingExecutor.runtime_startup()`
         and `RPDispatchingExecutor.runtime_shutdown()`.
@@ -320,24 +324,34 @@ class Runtime:
 
     @property
     def session(self) -> rp.Session:
+        """The current radical.pilot.Session (may already be closed)."""
         return self._session
 
     @typing.overload
     def pilot_manager(self) -> typing.Union[rp.PilotManager, None]:
-        """Get the current PilotManager, if any."""
         ...
 
     @typing.overload
-    def pilot_manager(self, pilot_manager: str) -> typing.Union[rp.PilotManager, None]:
-        """Set the pilot manager from a UID"""
+    def pilot_manager(self, pilot_manager: str) -> rp.PilotManager:
         ...
 
     @typing.overload
-    def pilot_manager(self, pilot_manager: rp.PilotManager) -> typing.Union[rp.PilotManager, None]:
-        """Set the current pilot manager as provided."""
+    def pilot_manager(self, pilot_manager: rp.PilotManager) -> rp.PilotManager:
         ...
 
     def pilot_manager(self, pilot_manager=None) -> typing.Union[rp.PilotManager, None]:
+        """Get (optionally set) the current PilotManager.
+
+        Args:
+            pilot_manager (optional, radical.pilot.PilotManager, str): Set to RP PilotManager instance or identifier, if provided.
+
+        Returns:
+            radical.pilot.PilotManager: instance, if set, else ``None``.
+
+        Raises:
+            ValueError: for invalid identifier.
+            APIError: for invalid RP Session configuration.
+        """
         if pilot_manager is None:
             return self._pilot_manager
         elif isinstance(pilot_manager, rp.PilotManager):
@@ -360,20 +374,29 @@ class Runtime:
 
     @typing.overload
     def task_manager(self) -> typing.Union[rp.TaskManager, None]:
-        """Get the current TaskManager, if any."""
         ...
 
     @typing.overload
-    def task_manager(self, task_manager: str) -> typing.Union[rp.TaskManager, None]:
-        """Set the TaskManager from a UID."""
+    def task_manager(self, task_manager: str) -> rp.TaskManager:
         ...
 
     @typing.overload
-    def task_manager(self, task_manager: rp.TaskManager) -> typing.Union[rp.TaskManager, None]:
-        """Set the TaskManager from the provided instance."""
+    def task_manager(self, task_manager: rp.TaskManager) -> rp.TaskManager:
         ...
 
     def task_manager(self, task_manager=None) -> typing.Union[rp.TaskManager, None]:
+        """Get (optionally set) the current TaskManager.
+
+        Args:
+            task_manager (optional, radical.pilot.TaskManager, str): Set to RP TaskManager instance or identifier, if provided.
+
+        Returns:
+            radical.pilot.TaskManager: instance, if set, else ``None``.
+
+        Raises:
+            ValueError: for invalid identifier.
+            APIError: for invalid RP Session configuration.
+        """
         if task_manager is None:
             return self._task_manager
         elif isinstance(task_manager, rp.TaskManager):
@@ -396,17 +419,14 @@ class Runtime:
 
     @typing.overload
     def pilot(self) -> typing.Union[rp.Pilot, None]:
-        """Get the current Pilot, if any."""
         ...
 
     @typing.overload
-    def pilot(self, pilot: str) -> typing.Union[rp.Pilot, None]:
-        """Set the Pilot according to the provided UID."""
+    def pilot(self, pilot: str) -> rp.Pilot:
         ...
 
     @typing.overload
-    def pilot(self, pilot: rp.Pilot) -> typing.Union[rp.Pilot, None]:
-        """Set the Pilot to the provided instance."""
+    def pilot(self, pilot: rp.Pilot) -> rp.Pilot:
         ...
 
     def pilot(self, pilot=None) -> typing.Union[rp.Pilot, None]:
@@ -417,6 +437,10 @@ class Runtime:
 
         Returns:
             radical.pilot.Pilot: instance, if set, else ``None``
+
+        Raises:
+            ValueError: for invalid identifier.
+            APIError: for invalid RP Session configuration.
         """
         if pilot is None:
             return self._pilot

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -343,7 +343,8 @@ class Runtime:
         """Get (optionally set) the current PilotManager.
 
         Args:
-            pilot_manager (optional, radical.pilot.PilotManager, str): Set to RP PilotManager instance or identifier, if provided.
+            pilot_manager (optional, radical.pilot.PilotManager, str):
+                Set to RP PilotManager instance or identifier, if provided.
 
         Returns:
             radical.pilot.PilotManager: instance, if set, else ``None``.
@@ -388,7 +389,8 @@ class Runtime:
         """Get (optionally set) the current TaskManager.
 
         Args:
-            task_manager (optional, radical.pilot.TaskManager, str): Set to RP TaskManager instance or identifier, if provided.
+            task_manager (optional, radical.pilot.TaskManager, str):
+                Set to RP TaskManager instance or identifier, if provided.
 
         Returns:
             radical.pilot.TaskManager: instance, if set, else ``None``.

--- a/src/scalems/store/__init__.py
+++ b/src/scalems/store/__init__.py
@@ -708,7 +708,7 @@ def get_file_reference(obj, filestore=None, mode="rb") -> typing.Coroutine[None,
     attempts to retrieve a reference to the identified filesystem object.
 
     Note:
-        If *obj* is a `str` or `bytes`, *obj* is interpreted as a `ResourceIdentifier`,
+        If *obj* is a `str` or :py:class:`bytes`, *obj* is interpreted as a `ResourceIdentifier`,
         **not** as a filesystem path.
 
     This involves placing (copying) the file, reading the file to fingerprint it,


### PR DESCRIPTION
* Fix docstrings for overloaded methods.
* Minor update to scalems.compat.get_to_thread(): Make our compatibility function match the Py 3.9 version more closely.