### PR TITLE
Collect coverage data on execution side.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -28,8 +28,12 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+    if typing.TYPE_CHECKING:
     raise NotImplementedError
     \.\.\.
+
+    # Ignore some error handling we hope to never trigger or isn't worth testing:
+    except ImportError:
 
 ignore_errors = True
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -32,6 +32,10 @@ exclude_lines =
     raise NotImplementedError
     \.\.\.
 
+    # Don't complain if non-coverable code isn't run:
+    if self._Coverage is not None:
+    if self.cov is not None:
+
     # Ignore some error handling we hope to never trigger or isn't worth testing:
     except ImportError:
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 source = scalems
+concurrency = thread
 
 [report]
 # Regexes for lines to exclude from consideration
@@ -34,5 +35,3 @@ ignore_errors = True
 
 omit =
     */scalems/_version.py
-    # We don't currently have a way to get coverage results for these installed scripts.
-    */scalems/radical/raptor.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -330,6 +330,7 @@ jobs:
           tests \
           --rp-venv $HOME/testenv --rp-resource=local.github --rp-access=ssh
         cd scalems-remote-coverage-dir
+        cp coverage_dir/.coverage* ./
         coverage combine --keep
         coverage xml --rcfile=../.coveragerc -o coverage-remote.xml
         cd ..

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,10 +116,12 @@ jobs:
         ls $HOME
         pwd
         ls
+        python -m coverage --version
         python -X dev -m pytest --cov=scalems --cov-report=xml tests -s
     - name: Command line tests
       run: |
         . $HOME/testenv/bin/activate
+        coverage --version
         coverage run -m scalems.local --version
         coverage run --append -m scalems.local --help
         # We clean the working directory now, but we will need better handling for
@@ -203,6 +205,7 @@ jobs:
         ls $HOME
         echo "Working directory: $(pwd)"
         ls
+        python -m coverage --version
         python -X dev -m pytest -x \
           --cov=scalems --cov-report=xml:coverage.xml \
           -rA -l --full-trace --log-cli-level=debug \
@@ -214,6 +217,7 @@ jobs:
         RADICAL_PILOT_DBURL: mongodb://root:password@localhost:${{ job.services.mongodb.ports[27017] }}/admin
       run: |
         . $HOME/testenv/bin/activate
+        coverage --version
         coverage run -m scalems.radical --version
         coverage run --append -m scalems.radical --help
         # We clean the working directory now, but we will need better handling for
@@ -313,6 +317,7 @@ jobs:
         ssh-add ~/.ssh/id
         . $HOME/testenv/bin/activate
         export RADICAL_LOG_LVL=DEBUG
+        python -m coverage --version
         python -c "import os; import pymongo; print('Create test entry in DB: ', pymongo.MongoClient(os.getenv('RADICAL_PILOT_DBURL')).test.test.insert_one({'x': 10}).inserted_id)"
         ulimit -n 65536
         echo "HOME=$HOME"
@@ -320,10 +325,14 @@ jobs:
         pwd
         ls
         python -X dev -m pytest -x \
-          --cov=scalems --cov-report=xml:coverage.xml \
+          --cov --cov-config=.coveragerc --cov-report=xml:coverage.xml \
           -rA -l --full-trace --log-cli-level=debug \
           tests \
           --rp-venv $HOME/testenv --rp-resource=local.github --rp-access=ssh
+        cd scalems-remote-coverage-dir
+        coverage combine --keep
+        coverage xml --rcfile=../.coveragerc -o coverage-remote.xml
+        cd ..
     - name: Command line tests
       timeout-minutes: 5
       env:
@@ -332,6 +341,7 @@ jobs:
         eval "$(ssh-agent -s)"
         ssh-add ~/.ssh/id
         . $HOME/testenv/bin/activate
+        coverage --version
         coverage run -m scalems.radical --version
         coverage run --append -m scalems.radical --help
         # We clean the working directory now, but we will need better handling for
@@ -443,6 +453,7 @@ jobs:
         ls $HOME
         pwd
         ls
+        python -m coverage --version
         python -X dev -m pytest -x \
           --cov=scalems --cov-report=xml:coverage.xml \
           -rA -l --full-trace --log-cli-level=debug \
@@ -457,6 +468,7 @@ jobs:
         eval "$(ssh-agent -s)"
         ssh-add ~/.ssh/id
         . $HOME/testenv/bin/activate
+        coverage --version
         coverage run -m scalems.radical --version
         coverage run --append -m scalems.radical --help
         # We clean the working directory now, but we will need better handling for

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -93,14 +93,18 @@ When ``COVERAGE_RUN`` or ``SCALEMS_COVERAGE`` environment variables are detected
 ``python -m coverage run --data-file=coverage_dir/.coverage --parallel-mode ...``,
 and adds an output staging directive to retrieve ``task:///coverage_dir``
 to the predictably named directory ``./scalems-remote-coverage-dir``.
-to a uniquely named local subdirectory (`f"coverage-{str(master_identity)}"`).
 The ``--parallel-mode`` option makes sure that remotely generated master task
-coverage will be uniquely named.
+coverage data file will be uniquely named.
 
-Even though the `Master.request_cb()` and `Master.result_cb()` are called in
-separate threads spawned by RP, coverage should be correct.
+Note that :py:mod:`pytest-cov` does not set the ``COVERAGE_RUN`` environment
+variable. When :command:`pytest --cov` is detected, we use a pytest fixture to
+set ``SCALEMS_COVERAGE=TRUE`` in the testing process environment.
+
+Even though the `ScaleMSRaptor.request_cb()` and `ScaleMSRaptor.result_cb()` are
+called in separate threads spawned by RP, coverage should be correct.
 
 We cannot customize the command line for launching the Worker task, so for
 coverage of the Worker and its dispatched function calls, we need to use the
 Coverage API.
-*TBD*
+These details are encapsulated in the
+:py:func:`scalems.radical.raptor.coverage_file` decorator.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -59,3 +59,48 @@ scripting interface behaves as expected.
     as possible about experimental features or use cases, but that would require
     either packaging the tests in some way or at least manipulating the
     PYTHONPATH and making them ``import``-able.
+
+Coverage
+========
+
+We use the Python `Coverage <https://coverage.readthedocs.io/>`__ package to
+trace test coverage.
+(For pytest tests, we use the `pytest-cov <https://pytest-cov.readthedocs.io/>`__
+pytest plugin.)
+In our GitHub Actions test pipeline, we gather coverage for both pytest suites
+and command line examples, and upload the results to
+`Codecov.io <https://app.codecov.io/gh/SCALE-MS/scale-ms>`__ for visualization
+and for feedback on pull requests.
+
+Aggregating coverage
+--------------------
+
+The ``--parallel-mode`` works pretty well to gather multiple data files, and
+codecov.io does a good job of automatically merging multiple reports received
+from a pipeline. We just have to make sure to use ``--append``
+(or ``--cov-append``) appropriately for the data files, and to create appropriately
+unique xml report files (for upload).
+
+The default ``coverage`` behavior automatically follows threads, too.
+However, for processes launched by RADICAL Pilot, we need to take extra steps
+to run coverage and gather results.
+
+Gathering remote coverage
+-------------------------
+
+When ``COVERAGE_RUN`` or ``SCALEMS_COVERAGE`` environment variables are detected,
+:py:mod:`scalems.radical.runtime` modifies the Master TaskDescription to include
+``python -m coverage run --data-file=coverage_dir/.coverage --parallel-mode ...``,
+and adds an output staging directive to retrieve ``task:///coverage_dir``
+to the predictably named directory ``./scalems-remote-coverage-dir``.
+to a uniquely named local subdirectory (`f"coverage-{str(master_identity)}"`).
+The ``--parallel-mode`` option makes sure that remotely generated master task
+coverage will be uniquely named.
+
+Even though the `Master.request_cb()` and `Master.result_cb()` are called in
+separate threads spawned by RP, coverage should be correct.
+
+We cannot customize the command line for launching the Worker task, so for
+coverage of the Worker and its dispatched function calls, we need to use the
+Coverage API.
+*TBD*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,6 +1,6 @@
 black
 build
-coverage
+coverage>=6.1
 flake8
 packaging
 pytest>=6.1.2

--- a/src/scalems/radical/raptor/__init__.py
+++ b/src/scalems/radical/raptor/__init__.py
@@ -299,7 +299,7 @@ if typing.TYPE_CHECKING:
 # rearranging the import order of built-in versus third-party modules.
 try:
     import radical.pilot as rp
-except (ImportError,):
+except ImportError:
     warnings.warn("RADICAL Pilot installation not found.")
 
 import scalems.exceptions

--- a/src/scalems/radical/raptor/__init__.py
+++ b/src/scalems/radical/raptor/__init__.py
@@ -280,6 +280,7 @@ import typing
 import warnings
 import weakref
 import zlib
+from contextlib import ContextDecorator
 from importlib.machinery import ModuleSpec
 from importlib.util import find_spec
 from collections.abc import Generator
@@ -640,6 +641,7 @@ def _(obj: RaptorConfiguration) -> dict:
     return dataclasses.asdict(obj)
 
 
+# TODO: Remove? This is effectively replaced by scalems.radical.raptor.__main__.py
 @functools.cache
 def raptor_script() -> str:
     """Get the name of the RP raptor raptor script.
@@ -762,6 +764,85 @@ def worker_requirements(*, pre_exec: typing.Iterable[str], worker_venv: str) -> 
 
 parser = argparse.ArgumentParser(description="Command line entry point for RP raptor task.")
 parser.add_argument("file", type=str, help="Input file (JSON) for configuring ScaleMSRaptor instance.")
+
+
+class coverage_file(ContextDecorator):
+    """Decorator for a function to conditionally record to the named coverage data file."""
+
+    _Coverage = None
+    cov = None
+    _decorated_function = ""
+
+    def __init__(self, filename=".coverage", verbose=True):
+        self.filename = filename
+        self.verbose = verbose
+        if os.getenv("COVERAGE_RUN") is not None or os.getenv("SCALEMS_COVERAGE") is not None:
+            logger.info("... testing with coverage")
+            try:
+                from coverage import Coverage
+
+                self._Coverage = Coverage
+            except ImportError:
+                warnings.warn("Code coverage reporting is not available.")
+        else:
+            logger.info("No coverage testing")
+
+    def __call__(self, func):
+        # Apply the decorator
+        assert callable(func)
+        self._decorated_function = func.__qualname__
+        # Return the decorated function.
+        return super().__call__(func)
+
+    def __enter__(self):
+        if self._Coverage is not None:
+            current_pid = os.getpid()
+            coverage_pid = os.environ.get("SCALEMS_COVERAGE_ACTIVE", None)
+            if coverage_pid is not None:
+                if int(coverage_pid) != current_pid:
+                    logger.info(f"PID {current_pid} inheriting coverage from {coverage_pid}.")
+                else:
+                    logger.info(f"{self._decorated_function}: Coverage API is already active for {current_pid}.")
+                    # warnings.warn(f'Coverage API is already active in {current_pid}. Data race may occur.')
+                    # TODO: Check whether this is a problem since result_cb() may be reentrant.
+            else:
+                coverage_pid = current_pid
+                os.environ["SCALEMS_COVERAGE_ACTIVE"] = str(current_pid)
+                logger.info(f"Starting coverage for {coverage_pid} in {os.getcwd()}")
+                filename = self.filename
+                if not os.path.isabs(filename):
+                    filename = os.path.join(".", "coverage_dir", filename)
+                self.filename = os.path.abspath(filename)
+                if not os.path.exists(os.path.dirname(filename)):
+                    os.mkdir(os.path.dirname(filename))
+
+                self.cov = self._Coverage(
+                    auto_data=True,
+                    branch=True,
+                    check_preimported=True,
+                    data_file=filename,
+                    data_suffix=self._decorated_function,
+                    messages=self.verbose,
+                    source=("scalems",),
+                )
+                self.cov.start()
+        return self
+
+    def __exit__(self, *exc):
+        if self.cov is not None:
+            current_pid = os.getpid()
+            coverage_pid_str = os.environ.get("SCALEMS_COVERAGE_ACTIVE", None)
+            if coverage_pid_str == str(current_pid):
+                logger.info(f"Saving coverage data for {self._decorated_function} to {self.filename}.")
+                self.cov.stop()
+                self.cov.save()
+                del os.environ["SCALEMS_COVERAGE_ACTIVE"]
+            else:
+                logger.info(
+                    f"Deferring coverage for {self._decorated_function} on {current_pid} to PID {coverage_pid_str}."
+                )
+            del self.cov
+        return False
 
 
 def raptor():
@@ -888,7 +969,7 @@ def raptor():
             logger.info(message)
 
             _raptor.start()
-            logger.debug("Raptor started.")
+            logger.debug(f"Raptor started in PID {os.getpid()}: {' '.join(sys.argv)}.")
 
             # Make sure at least one worker comes online.
             _raptor.wait_workers(count=1)
@@ -925,7 +1006,8 @@ def _configure_worker(*, requirements: ClientWorkerRequirements, filename: str) 
         cpu_processes=requirements.cpu_processes,
         gpus_per_process=requirements.gpus_per_process,
     )
-
+    if os.getenv("COVERAGE_RUN") is not None or os.getenv("SCALEMS_COVERAGE") is not None:
+        descr.environment = {"SCALEMS_COVERAGE": "TRUE"}
     config: RaptorWorkerConfig = [descr] * num_workers
     return config
 
@@ -1445,6 +1527,8 @@ class ScaleMSWorker(rp.raptor.MPIWorker):
 
     """
 
+    # TODO: How to get the module logger output for the Worker task.
+    @coverage_file()
     def run_in_worker(self, *, work_item: ScalemsRaptorWorkItem, comm=None):
         """Unpack and run a task requested through RP Raptor.
 
@@ -1471,7 +1555,7 @@ class ScaleMSWorker(rp.raptor.MPIWorker):
                 kwargs[comm_arg_name] = comm
             else:
                 args.append(comm)
-        logger.debug(
+        self._log.debug(
             "Calling {func} with args {args} and kwargs {kwargs}",
             {"func": func.__qualname__, "args": repr(args), "kwargs": repr(kwargs)},
         )

--- a/src/scalems/radical/raptor/__main__.py
+++ b/src/scalems/radical/raptor/__main__.py
@@ -1,0 +1,28 @@
+"""Entry point for the Master Task role of the scalems.radical.raptor module.
+
+An alternative to the setuptools generated entry-point script (:file:`scalems_rp_master`).
+"""
+
+import sys
+
+if __name__ == "__main__":
+    import logging
+
+    scalems_logger = logging.getLogger("scalems")
+
+    # TODO: Configurable log level?
+    scalems_logger.setLevel(logging.DEBUG)
+    character_stream = logging.StreamHandler()
+    character_stream.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    character_stream.setFormatter(formatter)
+    scalems_logger.addHandler(character_stream)
+
+    file_logger = logging.FileHandler("scalems.radical.raptor.log")
+    file_logger.setLevel(logging.DEBUG)
+    file_logger.setFormatter(formatter)
+    logging.getLogger("scalems").addHandler(file_logger)
+
+    from scalems.radical.raptor import raptor
+
+    sys.exit(raptor())

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -180,7 +180,6 @@ from scalems.exceptions import MissingImplementationError
 from scalems.exceptions import ProtocolError
 from scalems.exceptions import ScaleMSError
 from .raptor import raptor_input
-from .raptor import raptor_script
 from ..store import FileStore
 from ..execution import AbstractWorkflowUpdater
 from ..execution import RuntimeManager

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -147,6 +147,7 @@ import logging
 import os
 import pathlib
 import shutil
+import sys
 import tempfile
 import threading
 import typing
@@ -587,9 +588,40 @@ async def _get_scheduler(
     # caller.
     # td.named_env = 'scalems_env'
 
-    # This is the name that should be resolvable in an active venv for the installed
-    # raptor task entry point script
-    td.executable = raptor_script()
+    td.executable = "python3"
+    td.arguments = []
+    if os.getenv("PYTHONDEVMODE", None) == "1" or "dev" in getattr(sys, "_xoptions", {}):
+        td.arguments.extend(("-X", "dev"))
+    if os.getenv("COVERAGE_RUN") is not None or os.getenv("SCALEMS_COVERAGE") is not None:
+        # TODO: Use the FileStore!
+        local_coverage_dir = pathlib.Path("scalems-remote-coverage-dir").resolve()
+        td.arguments.extend(
+            (
+                "-m",
+                "coverage",
+                "run",
+                "--parallel-mode",
+                "--source=scalems",
+                "--branch",
+                "--data-file=coverage_dir/.coverage",
+            )
+        )
+        td.environment["SCALEMS_COVERAGE"] = "TRUE"
+        td.environment["RADICAL_LOG_LVL"] = "DEBUG"
+        td.pre_exec.append("mkdir -p coverage_dir")
+        td.output_staging.extend(
+            (
+                {
+                    "source": "task:///coverage_dir",
+                    "target": local_coverage_dir.as_uri(),
+                    "action": rp.TRANSFER,
+                },
+            )
+        )
+        logger.info(f"Coverage data will be staged to {local_coverage_dir}.")
+    else:
+        logger.debug("No coverage testing")
+    td.arguments.extend(("-m", "scalems.radical.raptor"))
 
     logger.debug(f"Using {filestore}.")
 
@@ -607,7 +639,7 @@ async def _get_scheduler(
     td.input_staging = [
         {
             "source": config_file.as_uri(),
-            "target": f"{config_file_name}",
+            "target": f"task:///{config_file_name}",
             "action": rp.TRANSFER,
         }
     ]

--- a/src/scalems/workflow/__init__.py
+++ b/src/scalems/workflow/__init__.py
@@ -253,6 +253,8 @@ class Task:
 
     def __init__(self, manager: "WorkflowManager", record: str):
         self._serialized_record = str(record)
+        # TODO: Establish and check the serialization scheme / JSON schema.
+        # I.e. the result type of Task.serialize()
         decoded_record = json.loads(self._serialized_record)
 
         self._uid = bytes.fromhex(decoded_record["uid"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,19 @@ def rmtmp(request):
     return choice
 
 
+@pytest.fixture(autouse=True)
+def propagate_coverage(request):
+    """Detect the activity of the pytest-cov plugin.
+
+    The COVERAGE_RUN environment variable provided by :py:mod:`coverage` is not
+    set when coverage is managed through the :py:mod:`pytest-cov` plugin. We
+    look for the presence of that pytest command line flag and set
+    SCALEMS_COVERAGE=TRUE if detected.
+    """
+    if request.config.getoption("--cov"):
+        os.environ["SCALEMS_COVERAGE"] = "TRUE"
+
+
 @contextmanager
 def _cleandir(remove_tempdir: str = "always"):
     """Context manager for a clean temporary working directory.

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -3,4 +3,3 @@ minversion = 3.0
 asyncio_mode = auto
 env =
     D:RADICAL_LOG_LVL=DEBUG
-    D:SCALEMS_COVERAGE=TRUE

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -3,3 +3,4 @@ minversion = 3.0
 asyncio_mode = auto
 env =
     D:RADICAL_LOG_LVL=DEBUG
+    D:SCALEMS_COVERAGE=TRUE

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -101,6 +101,15 @@ async def test_raptor_master(pilot_description, rp_venv):
                     "uid": f"command-hello-{scalems.identifiers.EphemeralIdentifier()}",
                 }
             )
+            if os.getenv("COVERAGE_RUN") is not None or os.getenv("SCALEMS_COVERAGE") is not None:
+                hello_command_description.environment["SCALEMS_COVERAGE"] = "TRUE"
+                # TODO: Worker coverage.
+                # td.output_staging.append(
+                #     {
+                #         'source': os.path.join(scheduler.task_sandbox, 'coverage-worker.xml'),
+                #         'target': 'coverage-hello.xml',
+                #         'action': rp.TRANSFER
+                #     })
             logger.debug(f"Submitting {str(hello_command_description.as_dict())}")
             (hello_task,) = await asyncio.to_thread(
                 dispatcher.runtime.task_manager().submit_tasks, [hello_command_description]
@@ -219,6 +228,15 @@ async def test_worker(pilot_description, rp_venv):
             add_item_task_description.cpu_process_type = (rp.SERIAL,)
             add_item_task_description.mode = scalems.radical.raptor.CPI_MESSAGE
             add_item_task_description.metadata = scalems.messages.AddItem(json.dumps(work_item)).encode()
+            if os.getenv("COVERAGE_RUN") is not None or os.getenv("SCALEMS_COVERAGE") is not None:
+                add_item_task_description.environment["SCALEMS_COVERAGE"] = "TRUE"
+                # TODO: Worker coverage.
+                # task_description.output_staging.append(
+                #     {
+                #         'source': os.path.join(scheduler.task_sandbox, 'coverage-worker.xml'),
+                #         'target': 'coverage-scalems-test-worker.xml',
+                #         'action': rp.TRANSFER
+                #     })
 
             task_manager = dispatcher.runtime.task_manager()
 

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -101,15 +101,9 @@ async def test_raptor_master(pilot_description, rp_venv):
                     "uid": f"command-hello-{scalems.identifiers.EphemeralIdentifier()}",
                 }
             )
+            # TODO: Let this be the responsibility of the submitter internals.
             if os.getenv("COVERAGE_RUN") is not None or os.getenv("SCALEMS_COVERAGE") is not None:
                 hello_command_description.environment["SCALEMS_COVERAGE"] = "TRUE"
-                # TODO: Worker coverage.
-                # td.output_staging.append(
-                #     {
-                #         'source': os.path.join(scheduler.task_sandbox, 'coverage-worker.xml'),
-                #         'target': 'coverage-hello.xml',
-                #         'action': rp.TRANSFER
-                #     })
             logger.debug(f"Submitting {str(hello_command_description.as_dict())}")
             (hello_task,) = await asyncio.to_thread(
                 dispatcher.runtime.task_manager().submit_tasks, [hello_command_description]
@@ -228,15 +222,9 @@ async def test_worker(pilot_description, rp_venv):
             add_item_task_description.cpu_process_type = (rp.SERIAL,)
             add_item_task_description.mode = scalems.radical.raptor.CPI_MESSAGE
             add_item_task_description.metadata = scalems.messages.AddItem(json.dumps(work_item)).encode()
+            # TODO: Let this be the responsibility of the submitter internals.
             if os.getenv("COVERAGE_RUN") is not None or os.getenv("SCALEMS_COVERAGE") is not None:
                 add_item_task_description.environment["SCALEMS_COVERAGE"] = "TRUE"
-                # TODO: Worker coverage.
-                # task_description.output_staging.append(
-                #     {
-                #         'source': os.path.join(scheduler.task_sandbox, 'coverage-worker.xml'),
-                #         'target': 'coverage-scalems-test-worker.xml',
-                #         'action': rp.TRANSFER
-                #     })
 
             task_manager = dispatcher.runtime.task_manager()
 


### PR DESCRIPTION
Previously, the master task coverage data was never written because the master task does not complete. (Blocked by #253, #318, RP https://github.com/radical-cybertools/radical.pilot/compare/feature/raptor_api_2)

- [x] Update raptor session management with *coverage.py* wrappers.
- [x] Stage and merge coverage data.
- [x] Update raptor protocol with fixes for clean shut down and task directory management.
- [x] Collect Worker coverage.
- [x] Avoid *Task.cancel()* for the raptor. (Try to get clean shut down)
- [x] Make sure that environment variables and special code paths introduced during development of this PR are properly inactive when coverage reports are not desired.

Refs #278.