### PR TITLE
Update docker recipes for Python 3.9 default.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,7 +181,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip --version
         pip uninstall -y radical.pilot radical.saga radical.utils scalems
-        pip install radical.pilot~=1.18.0
+        pip install radical.pilot
         pip install -r requirements-testing.txt
         pip install .
         pip install coverage pymongo pytest-cov

--- a/docker/radicalpilot.dockerfile
+++ b/docker/radicalpilot.dockerfile
@@ -52,17 +52,23 @@ RUN apt-get update && \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y \
-        python3.8-dev \
         python3.9-dev \
-        python3.8-venv \
         python3.9-venv \
         python-dev-is-python3 \
         tox && \
     rm -rf /var/lib/apt/lists/*
 
+# Ubunuto:focal doesn't have python3.10 in the default repo as of this edit.
+#RUN apt-get update && \
+#    DEBIAN_FRONTEND=noninteractive \
+#    apt-get install -y \
+#        python3.10-dev \
+#        python3.10-venv && \
+#    rm -rf /var/lib/apt/lists/*
+
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 8
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 9
+#RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 10
 
 # Reference https://docs.docker.com/engine/examples/running_ssh_service/
 RUN mkdir /var/run/sshd

--- a/docker/rp-complete.dockerfile
+++ b/docker/rp-complete.dockerfile
@@ -38,9 +38,9 @@ RUN apt-get update && \
         locales \
         openmpi-bin \
         openssh-server \
-        python3.8 \
-        python3.8-dev \
-        python3.8-venv \
+        python3.9 \
+        python3.9-dev \
+        python3.9-venv \
         tox \
         vim \
         wget && \
@@ -50,7 +50,7 @@ RUN locale-gen en_US.UTF-8 && \
     update-locale LANG=en_US.UTF-8
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 9
 
 RUN groupadd radical && useradd -g radical -s /bin/bash -m rp
 
@@ -60,7 +60,7 @@ WORKDIR /home/rp
 
 ENV HOME=/home/rp
 ENV RPVENV=/home/rp/rp-venv
-RUN python3.8 -m venv $RPVENV
+RUN python3 -m venv $RPVENV
 
 RUN $RPVENV/bin/pip install --upgrade \
         pip \


### PR DESCRIPTION
The required Python version was updated in master, but the Docker recipes were still defaulting to Python 3.8.