### PR TITLE
Enable additional testing against RCT HEAD

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -442,7 +442,7 @@ jobs:
           -rA -l --full-trace --log-cli-level=debug \
           tests \
           --rp-venv $HOME/testenv --rp-resource=local.github --rp-access=ssh \
-          --experimental
+          --experimental --exhaustive
     - name: Command line tests
       timeout-minutes: 3
       env:

--- a/docker/scalems-rp.dockerfile
+++ b/docker/scalems-rp.dockerfile
@@ -11,14 +11,18 @@
 # The above command will use the parent directory as the "Docker build context" so that
 # the git repository contents are avaialble to the docker build script.
 #
+# Warning: The `mongo:focal` base image sets the HOME environment variable to /data/db for its own purposes,
+#    which breaks the meaning of `~` when executing with `-u rp`. Explicitly use `~rp` or use `--env HOME=/home/rp`
+#    in the `docker exec` command line.
+#
 # To run the `scalems` tests:
 # 1. Launch the container (as root, so that the mongod can be started).
 # 2. Wait a few seconds for the MongoDB service to start.
 # 3. Exec the tests in the container.
 #
-#     docker run --rm --name scalems_test -u root -d scalems-rp
+#     docker run --rm --name scalems_test -u root -d scalems/scalems-rp
 #     sleep 3
-#     docker exec -ti scalems_test bash -c ". rp-venv/bin/activate && python -m pytest scalems/tests -s"
+#     docker exec -ti -u rp -e HOME=/home/rp scalems_test bash -c ". rp-venv/bin/activate && python -m pytest scalems/tests -s"
 #     docker kill scalems_test
 
 # Prerequisite: build base image from rp-complete.dockerfile
@@ -27,15 +31,13 @@ FROM scalems/rp-complete:$TAG
 
 USER rp
 WORKDIR /home/rp
-ENV HOME=/home/rp
 
-RUN ./rp-venv/bin/pip install --no-cache-dir --upgrade pip setuptools
+RUN HOME=/home/rp ./rp-venv/bin/pip install --no-cache-dir --upgrade pip setuptools
 
 COPY --chown=rp:radical . scalems
 
-RUN ./rp-venv/bin/pip install --no-cache-dir --upgrade -r scalems/requirements-testing.txt
-RUN ./rp-venv/bin/pip install --no-cache-dir scalems/
+RUN HOME=/home/rp ./rp-venv/bin/pip install --no-cache-dir --upgrade -r scalems/requirements-testing.txt
+RUN HOME=/home/rp ./rp-venv/bin/pip install --no-cache-dir scalems/
 # The current rp and scalems packages should now be available to the rp user in /home/rp/rp-venv
 
 USER mongodb
-ENV HOME=/data/db


### PR DESCRIPTION
Resume applying the RP raptor tests in the `ssh_head` job that is allowed to fail.

Note: RP >= 1.21 currently fails the scalems raptor tests.

Update the Docker recipes so that the embedded example syntax works, and confirm our sense of what code paths work and which don't.