### PR TITLE
Defer `runtime_shutdown` to ThreadPoolExecutor.

### DIFF
--- a/src/scalems/execution.py
+++ b/src/scalems/execution.py
@@ -423,7 +423,7 @@ class RuntimeManager(typing.Generic[_BackendT], abc.ABC):
                     self._exception = e
             finally:
                 try:
-                    self.runtime_shutdown(runtime)
+                    await asyncio.to_thread(self.runtime_shutdown, runtime)
                 except asyncio.CancelledError as e:
                     cancelled_error = e
                 except Exception as e:

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -1108,7 +1108,6 @@ class RPDispatchingExecutor(RuntimeManager):
                 # we do not expect `cancel` to block, so we must wait for the
                 # cancellation to succeed. It shouldn't take long, but it is not
                 # instantaneous or synchronous. We hope that a minute is enough.
-                # TODO(#249): wrap in a thread, since this could take a few seconds.
                 final_state = runtime.scheduler.wait(state=rp.FINAL, timeout=60)
                 logger.debug(f"Final state: {final_state}")
                 logger.info(f"Master scheduling task state {runtime.scheduler.state}: {repr(runtime.scheduler)}.")


### PR DESCRIPTION
`RuntimeManager.runtime_shutdown()` is a (non-async) method with several blocking calls to RP, which caused the `async __aexit__` to block the event loop for ~25 seconds. By letting `RuntimeManager.__aexit__()` call `runtime_shutdown` as a separate thread, we fix the remaining warnings about long-running coroutines.