### PR TITLE
Check for valid scalems.radical.runtime Configuration.

### DIFF
--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -301,7 +301,7 @@ class Configuration:
         try:
             job_endpoint: ru.Url = rp.utils.misc.get_resource_job_url(hpc_platform_label, schema=access)
         except (TypeError, KeyError) as e:
-            raise RPConfigurationError(f'Could not resolve {access} access for {hpc_platform_label}') from e
+            raise RPConfigurationError(f"Could not resolve {access} access for {hpc_platform_label}") from e
 
         if self.enable_raptor:
             # scalems uses the RP MPIWorker, which can have problems in "local" execution modes.

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -11,7 +11,6 @@ Note: ``export RADICAL_LOG_LVL=DEBUG`` to enable RP debugging output.
 import asyncio
 import json
 import os
-import typing
 from subprocess import CompletedProcess
 from subprocess import run as subprocess_run
 
@@ -63,7 +62,7 @@ async def test_raptor_master(pilot_description, rp_venv):
     if rp_venv is None:
         pytest.skip("This test requires a user-provided static RP venv.")
 
-    if pilot_description.access_schema is "fork":
+    if pilot_description.access_schema == "fork":
         pytest.skip("Raptor is not fully supported with 'fork'-based launch methods.")
 
     loop = asyncio.get_event_loop()
@@ -162,7 +161,7 @@ async def test_worker(pilot_description, rp_venv):
         # Be sure to provision the venv.
         pytest.skip("This test requires a user-provided static RP venv.")
 
-    if pilot_description.access_schema is "fork":
+    if pilot_description.access_schema == "fork":
         pytest.skip("Raptor is not fully supported with 'fork'-based launch methods.")
 
     loop = asyncio.get_event_loop()

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -11,6 +11,7 @@ Note: ``export RADICAL_LOG_LVL=DEBUG`` to enable RP debugging output.
 import asyncio
 import json
 import os
+import typing
 from subprocess import CompletedProcess
 from subprocess import run as subprocess_run
 
@@ -61,6 +62,9 @@ async def test_raptor_master(pilot_description, rp_venv):
     # Hopefully, this requirement is temporary.
     if rp_venv is None:
         pytest.skip("This test requires a user-provided static RP venv.")
+
+    if pilot_description.access_schema is "fork":
+        pytest.skip("Raptor is not fully supported with 'fork'-based launch methods.")
 
     loop = asyncio.get_event_loop()
     loop.set_debug(True)
@@ -157,6 +161,9 @@ async def test_worker(pilot_description, rp_venv):
     if rp_venv is None:
         # Be sure to provision the venv.
         pytest.skip("This test requires a user-provided static RP venv.")
+
+    if pilot_description.access_schema is "fork":
+        pytest.skip("Raptor is not fully supported with 'fork'-based launch methods.")
 
     loop = asyncio.get_event_loop()
     loop.set_debug(True)

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -11,6 +11,7 @@ Note: ``export RADICAL_LOG_LVL=DEBUG`` to enable RP debugging output.
 import asyncio
 import json
 import os
+import typing
 from subprocess import CompletedProcess
 from subprocess import run as subprocess_run
 
@@ -22,6 +23,9 @@ import scalems.call
 import scalems.context
 import scalems.messages
 import scalems.workflow
+
+if typing.TYPE_CHECKING:
+    import radical.utils as ru
 
 try:
     import radical.pilot as rp
@@ -62,7 +66,11 @@ async def test_raptor_master(pilot_description, rp_venv):
     if rp_venv is None:
         pytest.skip("This test requires a user-provided static RP venv.")
 
-    if pilot_description.access_schema == "fork":
+    job_endpoint: ru.Url = rp.utils.misc.get_resource_job_url(
+        pilot_description.resource, pilot_description.access_schema
+    )
+    launch_method = job_endpoint.scheme
+    if launch_method == "fork":
         pytest.skip("Raptor is not fully supported with 'fork'-based launch methods.")
 
     loop = asyncio.get_event_loop()
@@ -161,7 +169,11 @@ async def test_worker(pilot_description, rp_venv):
         # Be sure to provision the venv.
         pytest.skip("This test requires a user-provided static RP venv.")
 
-    if pilot_description.access_schema == "fork":
+    job_endpoint: ru.Url = rp.utils.misc.get_resource_job_url(
+        pilot_description.resource, pilot_description.access_schema
+    )
+    launch_method = job_endpoint.scheme
+    if launch_method == "fork":
         pytest.skip("Raptor is not fully supported with 'fork'-based launch methods.")
 
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
* Make sure hpc platform label and access method are valid.
* Prevent `fork()` type Pilot when tasks spawn via MPI.
* Skip tests in incompatible configurations.

Ref #312.