### PR TITLE
Allow scalems.call to target raptor back end.

### DIFF
--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -346,6 +346,7 @@ async def test_rp_function(pilot_description, rp_venv, tmp_path):
         execution_target=pilot_description.resource,
         target_venv=rp_venv,
         rp_resource_params={"PilotDescription": pilot_description.as_dict()},
+        enable_raptor=True,
     )
 
     # Test RPDispatcher context


### PR DESCRIPTION
Support a lateral move of `scalems.call` dispatching to the raptor execution system. This is far from optimal (it executes a deserialized function in a command line subprocesses via the raptor PROC mode), but illustrates a minimal change to ensure that we don't lose any functionality by migrating back to raptor.

Immediate follow-up work needs to remove the scalems.call.cli layer and use native raptor function execution.

Ref #326