### PR TITLE
Allow scalems.call to dispatch through raptor

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     build:
       context: .
       dockerfile: ./radicalpilot.dockerfile
+      args:
+        GROMACS_SUFFIX: "_mpi"
       cache_from:
        - scalems/radicalpilot
     image: scalems/radicalpilot
@@ -68,5 +70,7 @@ services:
     build:
       context: .
       dockerfile: ./radicalpilot.dockerfile
+      args:
+        GROMACS_SUFFIX: "_mpi"
     image: scalems/radicalpilot
     restart: always

--- a/src/scalems/radical/raptor/__init__.py
+++ b/src/scalems/radical/raptor/__init__.py
@@ -729,6 +729,7 @@ async def master_input(
         # Note: the DuplicateKeyError could theoretically be the result of a
         # pre-existing file with the same internal path but a different key, but
         # such a condition would probably represent an internal error (bug).
+        # TODO: Migrate away from container behavior of FileStore.
         return filestore[key]
     else:
         return add_file_task.result()
@@ -1210,6 +1211,7 @@ class ScaleMSMaster(rp.raptor.Master):
                 mode = task["description"]["mode"]
                 # Allow non-scalems work to be handled normally.
                 if mode != CPI_MESSAGE:
+                    logger.debug(f"Deferring {str(task)} to regular RP handling.")
                     yield task
                     continue
                 else:

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -345,6 +345,13 @@ async def test_rp_function(pilot_description, rp_venv, tmp_path):
     if rp_venv is None:
         pytest.skip("This test requires a user-provided static RP venv.")
 
+    job_endpoint: ru.Url = rp.utils.misc.get_resource_job_url(
+        pilot_description.resource, pilot_description.access_schema
+    )
+    launch_method = job_endpoint.scheme
+    if launch_method == "fork":
+        pytest.skip("Raptor is not fully supported with 'fork'-based launch methods.")
+
     loop = asyncio.get_event_loop()
     loop.set_debug(True)
     logging.getLogger("asyncio").setLevel(logging.DEBUG)
@@ -354,6 +361,7 @@ async def test_rp_function(pilot_description, rp_venv, tmp_path):
         execution_target=pilot_description.resource,
         target_venv=rp_venv,
         rp_resource_params={"PilotDescription": pilot_description.as_dict()},
+        enable_raptor=True,
     )
 
     # Test RPDispatcher context
@@ -377,6 +385,18 @@ async def test_rp_function(pilot_description, rp_venv, tmp_path):
                 manager=manager,
                 requirements=None,
             )
+            # Note: the Master (and Worker) have already started, but may not be commensurate with *requirements*.
+            # Resource constraints:
+            # * the Master uses one of the cores available to the Pilot, so it is not available to Tasks.
+            # * Tasks cannot span Workers, so we need to make sure that we provision a sufficiently large Worker.
+            # * raptor does not support the memory/disk task constraints.
+            # * GPUs: gpus-per-rank is not well explored in raptor. deviations unknown.
+            # * nodes: Workers may span nodes, so this shouldn't be a problem.
+            # Other set-up details:
+            # * pre_exec needs to happen on the Worker, not the Task (default scalems pre_exec is already handled this way. We can add a check that user has not extended it until we can update the Worker provisioning.).
+            # * For 0th step, we can provision one Worker with all resources.
+            # * For immediate follow-up: Worker provisioning needs to be delayed, and carried out with respect to the work load.
+
             rp_task_result: scalems.radical.runtime.RPTaskResult = await scalems.radical.runtime.subprocess_to_rp_task(
                 call_handle, dispatcher=dispatcher
             )

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -385,17 +385,24 @@ async def test_rp_function(pilot_description, rp_venv, tmp_path):
                 manager=manager,
                 requirements=None,
             )
-            # Note: the Master (and Worker) have already started, but may not be commensurate with *requirements*.
+            # Note: the Master (and Worker) have already started, but may not be
+            # commensurate with *requirements*.
             # Resource constraints:
-            # * the Master uses one of the cores available to the Pilot, so it is not available to Tasks.
-            # * Tasks cannot span Workers, so we need to make sure that we provision a sufficiently large Worker.
+            # * the Master uses one of the cores available to the Pilot,
+            #   so it is not available to Tasks.
+            # * Tasks cannot span Workers, so we need to make sure that we
+            #   provision a sufficiently large Worker.
             # * raptor does not support the memory/disk task constraints.
             # * GPUs: gpus-per-rank is not well explored in raptor. deviations unknown.
             # * nodes: Workers may span nodes, so this shouldn't be a problem.
             # Other set-up details:
-            # * pre_exec needs to happen on the Worker, not the Task (default scalems pre_exec is already handled this way. We can add a check that user has not extended it until we can update the Worker provisioning.).
+            # * pre_exec needs to happen on the Worker, not the Task
+            #   (default scalems pre_exec is already handled this way.
+            #   We can add a check that user has not extended it until we can
+            #   update the Worker provisioning.).
             # * For 0th step, we can provision one Worker with all resources.
-            # * For immediate follow-up: Worker provisioning needs to be delayed, and carried out with respect to the work load.
+            # * For immediate follow-up: Worker provisioning needs to be delayed,
+            #   and carried out with respect to the work load.
 
             rp_task_result: scalems.radical.runtime.RPTaskResult = await scalems.radical.runtime.subprocess_to_rp_task(
                 call_handle, dispatcher=dispatcher


### PR DESCRIPTION
Use a traditional EXECUTABLE mode Task, but let the scalems.call Task go through the raptor protocol, touching the ScaleMSMaster.request_cb.

- [x] Determine the available cores in the Pilot.
- [X] Allow one core for an idle Worker. Work-load dependent Worker provisioning will be addressed in a follow-up. (See #318).
- [X] Test multi-core MPI task. (https://github.com/SCALE-MS/workshop/issues/8)

Resolves #326 