### PR TITLE
Update raptor protocols.

### DIFF
--- a/docs/executor_radical.rst
+++ b/docs/executor_radical.rst
@@ -111,7 +111,7 @@ interfaces in :py:mod:`radical.pilot.raptor`.
     :members:
     :exclude-members: __new__
 
-.. autoclass:: WorkerDescriptionDict
+.. autoclass:: WorkerDescription
     :members:
     :exclude-members: __new__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "dill",
     "mpi4py",
     "packaging",
-    "radical.pilot >= 1.20"
+    "radical.pilot >= 1.22"
 ]
 
 [project.urls]
@@ -31,7 +31,7 @@ test = [
     "pytest >= 6.1.2 ",
     "pytest-asyncio >= 0.14",
     "pytest-env",
-    "radical.pilot >= 1.20"
+    "radical.pilot >= 1.22"
 ]
 
 [project.scripts]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -16,7 +16,7 @@ ntplib
 pylint
 pymongo<4.0
 python-hostlist
-radical.pilot>=1.20
+radical.pilot>=1.22
 setproctitle
 tox>=2.0
 # Raptor MPI worker requirements

--- a/src/scalems/execution.py
+++ b/src/scalems/execution.py
@@ -534,7 +534,7 @@ async def manage_execution(executor: RuntimeManager, *, processing_state: asynci
                 raise ProtocolError("Expected a single key-value pair.")
             logger.debug(f"Processing command {repr(command)}")
 
-            # TODO: Use formal RPC protocol.
+            # TODO(#23): Use formal RPC protocol.
             if "control" in command:
                 if command["control"] == "stop":
                     logger.debug("Execution manager received stop command.")
@@ -542,6 +542,7 @@ async def manage_execution(executor: RuntimeManager, *, processing_state: asynci
                     # obvious.
                     # Consider explicit `break` to clarify that we want to run off the end
                     # of the function.
+                    # TODO: Send a stop command to the remote executor.
                     return
                 else:
                     raise ProtocolError("Unknown command: {}".format(command["control"]))

--- a/src/scalems/radical/raptor/__init__.py
+++ b/src/scalems/radical/raptor/__init__.py
@@ -510,7 +510,9 @@ class CpiAddItem(CpiCommand):
                 kwargs={"work_item": work_item},
             )
         )
-        # Note: There is no Task object returned from Master.submit_tasks()
+        # Note: There is no `Task` object returned from `Master.submit_tasks()`
+        # `Task` objects are currently only available on the client side;
+        # the agent side handles task dicts---which the master will receive through the *request_cb()*.
         manager.submit_tasks(scalems_task_description)
         logger.debug(f"Submitted {str(scalems_task_description)} in support of {str(task)}.")
 

--- a/src/scalems/radical/raptor/__init__.py
+++ b/src/scalems/radical/raptor/__init__.py
@@ -324,7 +324,7 @@ logger = logging.getLogger(__name__)
 # * https://github.com/SCALE-MS/scale-ms/issues/255
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class BackendVersion:
     """Identifying information for the computing backend."""
 
@@ -418,6 +418,7 @@ class CpiHello(CpiCommand):
         task["stderr"] = ""
         task["exit_code"] = 0
         task["stdout"] = repr(backend_version)
+        # TODO: scalems object encoding.
         task["return_value"] = dataclasses.asdict(backend_version)
         logger.debug("Finalizing...")
         manager.cpi_finalize(task)

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -9,6 +9,7 @@ Note: ``export RADICAL_LOG_LVL=DEBUG`` to enable RP debugging output.
 """
 
 import asyncio
+import dataclasses
 import json
 import os
 import typing
@@ -21,6 +22,7 @@ import pytest
 import scalems
 import scalems.call
 import scalems.context
+import scalems.identifiers
 import scalems.messages
 import scalems.workflow
 
@@ -89,28 +91,36 @@ async def test_raptor_master(pilot_description, rp_venv):
             logger.debug(f"test_raptor_master Session is {repr(dispatcher.runtime.session)}")
 
             # Bypass the scalems machinery and submit an instruction directly to the master task.
+            # TODO: Use scalems.radical.runtime.submit()
             scheduler: rp.Task = dispatcher.runtime.scheduler
-            td = rp.TaskDescription(
+            hello_command_description = rp.TaskDescription(
                 from_dict={
                     "scheduler": scheduler.uid,
                     "mode": scalems.radical.raptor.CPI_MESSAGE,
                     "metadata": scalems.messages.HelloCommand().encode(),
-                    "uid": "task-hello",
+                    "uid": f"command-hello-{scalems.identifiers.EphemeralIdentifier()}",
                 }
             )
-            logger.debug(f"Submitting {str(td.as_dict())}")
-            tasks = await asyncio.to_thread(dispatcher.runtime.task_manager().submit_tasks, [td])
-            hello_task = tasks[0]
+            logger.debug(f"Submitting {str(hello_command_description.as_dict())}")
+            (hello_task,) = await asyncio.to_thread(
+                dispatcher.runtime.task_manager().submit_tasks, [hello_command_description]
+            )
             logger.debug(f"Submitted {str(hello_task.as_dict())}. Waiting...")
-            state = await asyncio.to_thread(hello_task.wait, state=rp.FINAL, timeout=timeout)
+            hello_state = await asyncio.to_thread(hello_task.wait, state=rp.FINAL, timeout=timeout)
             logger.debug(str(hello_task.as_dict()))
 
-            td.metadata = scalems.messages.StopCommand().encode()
-            td.output_staging = []
-            td.uid = "task-stop"
-            logger.debug(f"Submitting {str(td.as_dict())}")
-            tasks = await asyncio.to_thread(dispatcher.runtime.task_manager().submit_tasks, [td])
-            stop_task = tasks[0]
+            stop_command_description = rp.TaskDescription(
+                from_dict={
+                    "scheduler": scheduler.uid,
+                    "mode": scalems.radical.raptor.CPI_MESSAGE,
+                    "metadata": scalems.messages.Control.create("stop").encode(),
+                    "uid": f"command-stop--{scalems.identifiers.EphemeralIdentifier()}",
+                }
+            )
+            logger.debug(f"Submitting {str(stop_command_description.as_dict())}")
+            (stop_task,) = await asyncio.to_thread(
+                dispatcher.runtime.task_manager().submit_tasks, [stop_command_description]
+            )
 
             # We expect the status update -> DONE, even if self.stop() was called during result_cb for the task.
             stop_watcher = asyncio.create_task(
@@ -146,14 +156,10 @@ async def test_raptor_master(pilot_description, rp_venv):
 
             assert scheduler.state == rp.DONE
 
-    assert state == rp.DONE
+    assert hello_state == rp.DONE
     assert hello_task.stdout == repr(scalems.radical.raptor.backend_version)
     # Ref https://github.com/SCALE-MS/scale-ms/discussions/268
-    # assert task.return_value == scalems.__version__
-
-    # Note: As we refine the dispatching protocol, make sure we don't wait for STOP controls to finish.
-    #     state = await asyncio.wait_for(stop_watcher, timeout=120)
-    #     assert state in rp.states.FINAL
+    assert hello_task.return_value == dataclasses.asdict(scalems.radical.raptor.backend_version)
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -189,6 +195,7 @@ async def test_worker(pilot_description, rp_venv):
         func=print.__name__, module=print.__module__, args=["hello world"], kwargs={}, comm_arg_name=None
     )
 
+    timeout = 120
     manager = scalems.radical.workflow_manager(loop)
     with scalems.workflow.scope(manager, close_on_exit=True):
         assert not loop.is_closed()
@@ -199,7 +206,10 @@ async def test_worker(pilot_description, rp_venv):
             logger.debug(f"Session is {repr(dispatcher.runtime.session)}")
 
             task_uid = "add_item.scalems-test-worker"
+
+            # Submit a raptor task
             # Bypass the scalems machinery and submit an instruction directly to the master task.
+            # TODO: Use scalems.radical.runtime.submit()
             scheduler: rp.Task = dispatcher.runtime.scheduler
 
             add_item_task_description = rp.TaskDescription()
@@ -211,9 +221,7 @@ async def test_worker(pilot_description, rp_venv):
             add_item_task_description.metadata = scalems.messages.AddItem(json.dumps(work_item)).encode()
 
             task_manager = dispatcher.runtime.task_manager()
-            timeout = 120
-            # Submit a raptor task
-            # TODO: Use scalems.radical.runtime.submit()
+
             submitter = asyncio.create_task(
                 asyncio.to_thread(task_manager.submit_tasks, add_item_task_description), name="rp_submit"
             )

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -53,10 +53,6 @@ else:
     minimum_scalems_version = client_scalems_version.base_version
 
 
-# We either need to mock a RP agent or gather coverage files from remote environments.
-# This test does not add any coverage, and only adds measurable coverage or coverage
-# granularity if we either mock a RP agent or gather coverage files from remote environments.
-@pytest.mark.xfail(reason="Needs updates for shutdown behavior of rp.raptor.Master (Discussion #289)")
 @pytest.mark.asyncio
 async def test_raptor_master(pilot_description, rp_venv):
     """Check our ability to launch and interact with a Master task."""
@@ -202,40 +198,40 @@ async def test_worker(pilot_description, rp_venv):
             assert isinstance(dispatcher, scalems.radical.runtime.RPDispatchingExecutor)
             logger.debug(f"Session is {repr(dispatcher.runtime.session)}")
 
-            task_uid = "task.scalems-test-worker"
+            task_uid = "add_item.scalems-test-worker"
             # Bypass the scalems machinery and submit an instruction directly to the master task.
             scheduler: rp.Task = dispatcher.runtime.scheduler
 
-            task_description = rp.TaskDescription()
-            task_description.scheduler = scheduler.uid
-            task_description.uid = task_uid
-            task_description.cpu_processes = 1
-            task_description.cpu_process_type = (rp.SERIAL,)
-            task_description.mode = scalems.radical.raptor.CPI_MESSAGE
-            task_description.metadata = scalems.messages.AddItem(json.dumps(work_item)).encode()
+            add_item_task_description = rp.TaskDescription()
+            add_item_task_description.scheduler = scheduler.uid
+            add_item_task_description.uid = task_uid
+            add_item_task_description.cpu_processes = 1
+            add_item_task_description.cpu_process_type = (rp.SERIAL,)
+            add_item_task_description.mode = scalems.radical.raptor.CPI_MESSAGE
+            add_item_task_description.metadata = scalems.messages.AddItem(json.dumps(work_item)).encode()
 
             task_manager = dispatcher.runtime.task_manager()
             timeout = 120
             # Submit a raptor task
             # TODO: Use scalems.radical.runtime.submit()
-            watcher = asyncio.create_task(
-                asyncio.to_thread(task_manager.submit_tasks, task_description), name="rp_submit"
+            submitter = asyncio.create_task(
+                asyncio.to_thread(task_manager.submit_tasks, add_item_task_description), name="rp_submit"
             )
             try:
-                rp_watcher: rp.Task = await asyncio.wait_for(watcher, timeout=timeout)
+                submitted_rptask: rp.Task = await asyncio.wait_for(submitter, timeout=timeout)
             except asyncio.TimeoutError as e:
-                logger.exception(f"Waited more than {timeout} to submit {task_description}.")
-                watcher.cancel()
+                logger.exception(f"Waited more than {timeout} to submit {add_item_task_description}.")
+                submitter.cancel()
                 raise e
 
-            rp_future: asyncio.Task = await scalems.radical.runtime.rp_task(rp_watcher)
+            cpi_command_future: asyncio.Task = await scalems.radical.runtime.rp_task(submitted_rptask)
             try:
-                rp_task: rp.Task = await asyncio.wait_for(rp_future, timeout=timeout)
+                add_item_task: rp.Task = await asyncio.wait_for(cpi_command_future, timeout=timeout)
             except asyncio.TimeoutError as e:
-                logger.debug(f"Waited more than {timeout} for {rp_future}: {e}")
-                rp_future.cancel("Canceled after waiting too long.")
+                logger.debug(f"Waited more than {timeout} for {cpi_command_future}: {e}")
+                cpi_command_future.cancel("Canceled after waiting too long.")
                 raise e
-            assert rp_task.exit_code == 0
+            assert add_item_task.exit_code == 0
 
             # Ref https://github.com/SCALE-MS/scale-ms/discussions/268
             try:
@@ -244,14 +240,18 @@ async def test_worker(pilot_description, rp_venv):
                 # Ref: https://github.com/radical-cybertools/radical.pilot/issues/2807
                 rp_release = None
             if rp_release is not None and rp_release[0:2] == (1, 20):
-                assert rp_task.return_value is None
-                work_item_task_id = rp_task.stdout
+                assert add_item_task.return_value is None
+                work_item_task_id = add_item_task.stdout
             else:
-                assert rp_task.return_value is not None
-                work_item_task_id = rp_task.return_value
+                assert add_item_task.return_value is not None
+                work_item_task_id = add_item_task.return_value
 
             logger.debug(f"Master submitted task {work_item_task_id} to Worker.")
+            # We now have the ID of the Task supporting the workflow item we added.
+            # We can get the result from a report provided by the Master, or we can use
+            # some sort of query command (both TBD).
             # TODO(#229): Check an actual data result.
+            # TODO: Update the RPDispatchingExecutor to send the stop rpc call.
 
 
 # def test_rp_raptor_remote_docker(sdist, rp_task_manager):


### PR DESCRIPTION
* Require radical.pilot>=1.22
* Update raptor usage.
* Add a bunch of notes and clarifications.

In addition to new inline "todo" comments, note that we should separate the Worker start-up from the master startup, and provide CPI commands for starting/stopping the Worker(s).

Resolves #253