### PR TITLE
Normalize raptor terminology.

### DIFF
--- a/docker/scalems-gromacs.dockerfile
+++ b/docker/scalems-gromacs.dockerfile
@@ -167,7 +167,7 @@ RUN cd scalems && \
 
 # The current rp and scalems packages should now be available to the rp user in /home/rp/rp-venv
 
-#ENV REF=master
+#ENV REF=raptor
 #
 #RUN . $EXAMPLE/env38/bin/activate && \
 #    pip install --upgrade scalems@git+https://github.com/SCALE-MS/scale-ms.git@$REF

--- a/docker/scalems-lammps.dockerfile
+++ b/docker/scalems-lammps.dockerfile
@@ -120,7 +120,7 @@ RUN cd scalems && \
 
 # The current rp and scalems packages should now be available to the rp user in /home/rp/rp-venv
 
-#ENV REF=master
+#ENV REF=raptor
 #
 #RUN . $EXAMPLE/env38/bin/activate && \
 #    pip install --upgrade scalems@git+https://github.com/SCALE-MS/scale-ms.git@$REF

--- a/docs/executor_radical.rst
+++ b/docs/executor_radical.rst
@@ -42,27 +42,27 @@ scalems.radical.raptor
 .. automodule:: scalems.radical.raptor
     :no-members:
 
-master task
+raptor task
 ~~~~~~~~~~~
 
-`scalems` specialization of the "master" component in the
+`scalems` specialization of the "raptor" component in the
 :py:mod:`radical.pilot.raptor` federated scheduling protocol.
 
-.. autofunction:: master
+.. autofunction:: raptor
 
-.. autofunction:: master_script
+.. autofunction:: raptor_script
 
-.. autofunction:: master_input
+.. autofunction:: raptor_input
 
 .. autofunction:: worker_requirements
 
-.. autoclass:: MasterTaskConfiguration
+.. autoclass:: RaptorConfiguration
     :members:
 
 .. autoclass:: ClientWorkerRequirements
     :members:
 
-.. autoclass:: ScaleMSMaster
+.. autoclass:: ScaleMSRaptor
     :members:
 
 worker task
@@ -82,7 +82,7 @@ task handling
 `scalems` instructions are embedded in TaskDescriptions with the
 :py:data:`scalems.radical.raptor.CPI_MESSAGE` mode,
 using the :py:attr:`~radical.pilot.TaskDescription.metadata` field for the payload.
-Executable work is re-encoded by `ScaleMSMaster` for `ScaleMSWorker`
+Executable work is re-encoded by `ScaleMSRaptor` for `ScaleMSWorker`
 (using a `ScalemsRaptorWorkItem` in the *work_item* field of the *kwargs* of
 a ``TASK_FUNCTION`` mode Task)
 to be dispatched through `scalems` machinery in the Worker process.

--- a/docs/invocation.rst
+++ b/docs/invocation.rst
@@ -241,5 +241,5 @@ entirely from within Python.
 Such use cases are not yet well-supported in `scalems`.
 
 Refer to the
-`test suite <https://github.com/SCALE-MS/scale-ms/tree/master/tests>`__
+`test suite <https://github.com/SCALE-MS/scale-ms/tree/raptor/tests>`__
 for examples, or follow https://github.com/SCALE-MS/scale-ms/issues/82.

--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -6,7 +6,7 @@
 #        python -m scalems.local echo.py hi there && \
 #        ls * && cat */stdout'
 #
-# By default, the Docker image is built with scalems from the `master` branch.
+# By default, the Docker image is built with scalems from the `raptor` branch.
 # Specify the REF build argument for a specific branch or commit ID.
 # E.g. Build with
 #     docker build -t ex_basic --build-arg REF=74f20c26b1e453c958cdc678b2155da0f8d3f184 .
@@ -37,7 +37,7 @@ RUN python3 -m venv env38 && \
     . env38/bin/activate && \
     pip install --no-cache-dir --upgrade pip setuptools wheel
 
-ARG REF=master
+ARG REF=raptor
 
 RUN . $EXAMPLE/env38/bin/activate && \
     pip install --no-cache-dir --upgrade scalems@git+https://github.com/SCALE-MS/scale-ms.git@$REF

--- a/examples/basic_gmxapi/Dockerfile
+++ b/examples/basic_gmxapi/Dockerfile
@@ -76,7 +76,7 @@ RUN . env38/bin/activate && \
     . ~/gromacs2021/bin/GMXRC && \
     pip install --no-cache-dir --upgrade gmxapi
 
-ENV REF=master
+ENV REF=raptor
 
 RUN . $EXAMPLE/env38/bin/activate && \
     pip install --no-cache-dir --upgrade scalems@git+https://github.com/SCALE-MS/scale-ms.git@$REF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
 ]
 
 [project.scripts]
-scalems_rp_master = "scalems.radical.raptor:master"
+scalems_rp_master = "scalems.radical.raptor:raptor"
 
 [tool.setuptools]
 zip-safe = false

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -108,7 +108,7 @@ See Also:
     return
     client_runtime <- client_executor
     return scheduler
-    client_executor -> : runtime.scheduler.wait()
+    client_executor -> : runtime.raptor.wait()
     return
     end
     client_executor -> : session.close()
@@ -178,8 +178,8 @@ from scalems.exceptions import InternalError
 from scalems.exceptions import MissingImplementationError
 from scalems.exceptions import ProtocolError
 from scalems.exceptions import ScaleMSError
-from .raptor import master_input
-from .raptor import master_script
+from .raptor import raptor_input
+from .raptor import raptor_script
 from ..store import FileStore
 from ..execution import AbstractWorkflowUpdater
 from ..execution import RuntimeManager
@@ -332,7 +332,7 @@ class Runtime:
 
     _session: rp.Session
 
-    scheduler: typing.Optional[rp.Task] = None
+    raptor: typing.Optional[rp.Task] = None
     """The active raptor scheduler task, if any."""
 
     resources: typing.Optional[asyncio.Task[dict]] = None
@@ -357,9 +357,9 @@ class Runtime:
             session = session.uid
         if pilot := self._pilot:
             pilot = pilot.uid
-        if scheduler := self.scheduler:
-            scheduler = scheduler.uid
-        representation = f'<Runtime session:"{session}" pilot:"{pilot}" raptor:"{scheduler}">'
+        if raptor_id := self.raptor:
+            raptor_id = raptor_id.uid
+        representation = f'<Runtime session:"{session}" pilot:"{pilot}" raptor:"{raptor_id}">'
         return representation
 
     def reset(self, session: rp.Session):
@@ -381,7 +381,7 @@ class Runtime:
         # instance values seems a little harder to read.
         # TODO: Properly close previous session. This includes sending a "stop" to the
         #     raptor scheduler instead of letting it get a `Task.cancel()` (i.e. a SIGTERM).
-        self.scheduler = None
+        self.raptor = None
         self._pilot = None
         self._task_manager = None
         self._pilot_manager = None
@@ -549,29 +549,29 @@ async def _get_scheduler(
 ):
     """Establish the radical.pilot.raptor.Master task.
 
-    Create a master rp.Task (running the scalems_rp_master script) with the
+    Create a raptor rp.Task (running the scalems_rp_master script) with the
     provided *name* to be referenced as the *scheduler* for raptor tasks.
 
-    Returns the rp.Task for the master script once the Master is ready to
+    Returns the rp.Task for the raptor script once the Master is ready to
     receive submissions.
 
     Raises:
-        DispatchError if the master task could not be launched successfully.
+        DispatchError if the raptor task could not be launched successfully.
 
     Note:
-        Currently there is no completion condition for the master script.
+        Currently there is no completion condition for the raptor script.
         Caller is responsible for canceling the Task returned by this function.
     """
-    # define a raptor.scalems master and launch it within the pilot
+    # define a raptor.scalems raptor and launch it within the pilot
     td = rp.TaskDescription()
 
-    # The master uid is used as the `scheduler` value for raptor task routing.
+    # The raptor uid is used as the `scheduler` value for raptor task routing.
     # TODO(#108): Use caller-provided *name* for master_identity.
     # Master tasks may not appear unique, but must be uniquely identified within the
     # scope of a rp.Session for RP bookkeeping. Since there is no other interesting
     # information at this time, we can generate a random ID and track it in our metadata.
     master_identity = EphemeralIdentifier()
-    td.uid = "scalems-rp-master." + str(master_identity)
+    td.uid = "scalems-rp-raptor." + str(master_identity)
 
     td.mode = rp.RAPTOR_MASTER
 
@@ -579,7 +579,7 @@ async def _get_scheduler(
     # script may crash even before it can write anything, but if it does write
     # anything, we _will_ have the output file locally.
     # TODO: Why don't we have the output files? Can we ensure output files for CANCEL?
-    td.output_staging = []  # TODO(#229) Write and stage output from master task.
+    td.output_staging = []  # TODO(#229) Write and stage output from raptor task.
     td.stage_on_error = True
 
     td.pre_exec = list(pre_exec)
@@ -589,16 +589,16 @@ async def _get_scheduler(
     # td.named_env = 'scalems_env'
 
     # This is the name that should be resolvable in an active venv for the installed
-    # master task entry point script
-    td.executable = master_script()
+    # raptor task entry point script
+    td.executable = raptor_script()
 
     logger.debug(f"Using {filestore}.")
 
     # _original_callback_duration = asyncio.get_running_loop().slow_callback_duration
     # asyncio.get_running_loop().slow_callback_duration = 0.5
     config_file = await asyncio.create_task(
-        master_input(filestore=filestore, worker_pre_exec=list(pre_exec), worker_venv=scalems_env),
-        name="get-master-input",
+        raptor_input(filestore=filestore, worker_pre_exec=list(pre_exec), worker_venv=scalems_env),
+        name="get-raptor-input",
     )
     # asyncio.get_running_loop().slow_callback_duration = _original_callback_duration
 
@@ -622,24 +622,24 @@ async def _get_scheduler(
     logger.debug(f"Launching RP raptor scheduling. Submitting {td}.")
 
     _task = asyncio.create_task(asyncio.to_thread(task_manager.submit_tasks, td), name="submit-Master")
-    scheduler: rp.Task = await _task
+    raptor: rp.Task = await _task
 
     # WARNING: rp.Task.wait() *state* parameter does not handle tuples, but does not
     # check type.
     _task = asyncio.create_task(
-        asyncio.to_thread(scheduler.wait, state=[rp.states.AGENT_EXECUTING] + rp.FINAL),
+        asyncio.to_thread(raptor.wait, state=[rp.states.AGENT_EXECUTING] + rp.FINAL),
         name="check-Master-started",
     )
     await _task
-    logger.debug(f"Scheduler in state {scheduler.state}.")
+    logger.debug(f"Scheduler in state {raptor.state}.")
     # TODO: Generalize the exit status checker for the Master task and perform this
     #  this check at the call site.
-    if scheduler.state in rp.FINAL:
-        if scheduler.stdout or scheduler.stderr:
-            logger.error(f"scheduler.stdout: {scheduler.stdout}")
-            logger.error(f"scheduler.stderr: {scheduler.stderr}")
-        raise DispatchError(f"Master Task unexpectedly reached {scheduler.state} during launch.")
-    return scheduler
+    if raptor.state in rp.FINAL:
+        if raptor.stdout or raptor.stderr:
+            logger.error(f"raptor.stdout: {raptor.stdout}")
+            logger.error(f"raptor.stderr: {raptor.stderr}")
+        raise DispatchError(f"Master Task unexpectedly reached {raptor.state} during launch.")
+    return raptor
 
 
 # functools can't cache this function while Configuration is unhashable (due to
@@ -1124,13 +1124,13 @@ class RPDispatchingExecutor(RuntimeManager):
             # Can we report some more useful information, like job ID?
             _runtime.resources = asyncio.create_task(get_pilot_resources(pilot))
 
-            assert _runtime.scheduler is None
+            assert _runtime.raptor is None
 
             # Get a scheduler task IFF raptor is explicitly enabled.
             if config.enable_raptor:
                 # Note that _get_scheduler is a coroutine that, itself, returns a rp.Task.
                 # We await the result of _get_scheduler, then store the scheduler Task.
-                _runtime.scheduler = await asyncio.create_task(
+                _runtime.raptor = await asyncio.create_task(
                     _get_scheduler(
                         pre_exec=list(get_pre_exec(config)),
                         task_manager=task_manager,
@@ -1144,7 +1144,7 @@ class RPDispatchingExecutor(RuntimeManager):
             raise e
         except Exception as e:
             logger.exception("Exception while connecting RADICAL Pilot.", exc_info=e)
-            raise DispatchError("Failed to launch SCALE-MS master task.") from e
+            raise DispatchError("Failed to launch SCALE-MS raptor task.") from e
 
         self.runtime = _runtime
 
@@ -1175,19 +1175,19 @@ class RPDispatchingExecutor(RuntimeManager):
         logger.debug(f'Received command "{command}" for runtime {runtime}.')
         if runtime is None:
             raise scalems.exceptions.ScopeError("Cannot issue control commands without an active RuntimeManager.")
-        scheduler: rp.Task = runtime.scheduler
-        logger.debug(f"Preparing command for {repr(scheduler)}.")
-        if scheduler is None:
+        raptor: rp.Task = runtime.raptor
+        logger.debug(f"Preparing command for {repr(raptor)}.")
+        if raptor is None:
             raise scalems.exceptions.ScopeError(
                 f"Cannot issue control commands without an active RuntimeManager. {runtime}"
             )
-        if scheduler.state in rp.FINAL:
-            raise scalems.exceptions.ScopeError(f"Raptor scheduler is not available. {repr(scheduler)}")
-        assert scheduler.uid
+        if raptor.state in rp.FINAL:
+            raise scalems.exceptions.ScopeError(f"Raptor scheduler is not available. {repr(raptor)}")
+        assert raptor.uid
         message = scalems.messages.Control.create(command)
         td = rp.TaskDescription(
             from_dict={
-                "scheduler": scheduler.uid,
+                "raptor_id": raptor.uid,
                 "mode": scalems.radical.raptor.CPI_MESSAGE,
                 "metadata": message.encode(),
                 "uid": EphemeralIdentifier(),
@@ -1204,14 +1204,14 @@ class RPDispatchingExecutor(RuntimeManager):
             asyncio.to_thread(task.wait, state=rp.FINAL, timeout=timeout), name="cpi-watcher"
         )
 
-        scheduler_watcher = asyncio.create_task(
-            asyncio.to_thread(scheduler.wait, state=rp.FINAL, timeout=timeout), name="scheduler-watcher"
+        raptor_watcher = asyncio.create_task(
+            asyncio.to_thread(raptor.wait, state=rp.FINAL, timeout=timeout), name="raptor-watcher"
         )
-        # If master task fails, command-watcher will never complete.
+        # If raptor task fails, command-watcher will never complete.
         done, pending = await asyncio.wait(
-            (command_watcher, scheduler_watcher), timeout=timeout, return_when=asyncio.FIRST_COMPLETED
+            (command_watcher, raptor_watcher), timeout=timeout, return_when=asyncio.FIRST_COMPLETED
         )
-        if scheduler_watcher in done and command_watcher in pending:
+        if raptor_watcher in done and command_watcher in pending:
             command_watcher.cancel()
         logger.debug(str(task.as_dict()))
         # WARNING: Dropping the Task reference will cause its deletion.
@@ -1233,37 +1233,37 @@ class RPDispatchingExecutor(RuntimeManager):
         if session.closed:
             logger.error("Runtime Session is already closed?!")
         else:
-            if runtime.scheduler is not None:
+            if runtime.raptor is not None:
                 # Note: The __aexit__ for the RuntimeManager makes sure that a `stop`
                 # is issued after the work queue is drained, if the scheduler task has
                 # not already ended. We could check the status of this stop message...
-                if runtime.scheduler.state not in rp.FINAL:
-                    logger.info(f"Waiting for RP Raptor master task {runtime.scheduler.uid} to complete...")
-                    runtime.scheduler.wait(rp.FINAL, timeout=60)
-                if runtime.scheduler.state not in rp.FINAL:
-                    # Cancel the master.
-                    logger.warning("Canceling the master scheduling task.")
+                if runtime.raptor.state not in rp.FINAL:
+                    logger.info(f"Waiting for RP Raptor raptor task {runtime.raptor.uid} to complete...")
+                    runtime.raptor.wait(rp.FINAL, timeout=60)
+                if runtime.raptor.state not in rp.FINAL:
+                    # Cancel the raptor.
+                    logger.warning("Canceling the raptor scheduling task.")
                     # Note: the effect of CANCEL is to send SIGTERM to the shell that
                     # launched the task process.
                     # TODO: Report incomplete tasks and handle the consequences of terminating the
                     #  Raptor processes early.
                     task_manager = runtime.task_manager()
-                    task_manager.cancel_tasks(uids=runtime.scheduler.uid)
+                    task_manager.cancel_tasks(uids=runtime.raptor.uid)
                 # As of https://github.com/radical-cybertools/radical.pilot/pull/2702,
                 # we do not expect `cancel` to block, so we must wait for the
                 # cancellation to succeed. It shouldn't take long, but it is not
                 # instantaneous or synchronous. We hope that a minute is enough.
-                final_state = runtime.scheduler.wait(state=rp.FINAL, timeout=10)
+                final_state = runtime.raptor.wait(state=rp.FINAL, timeout=10)
                 logger.debug(f"Final state: {final_state}")
-                logger.info(f"Master scheduling task state {runtime.scheduler.state}: {repr(runtime.scheduler)}.")
-                if runtime.scheduler.stdout:
+                logger.info(f"Master scheduling task state {runtime.raptor.state}: {repr(runtime.raptor)}.")
+                if runtime.raptor.stdout:
                     # TODO(#229): Fetch actual stdout file.
-                    logger.debug(runtime.scheduler.stdout)
-                if runtime.scheduler.stderr:
+                    logger.debug(runtime.raptor.stdout)
+                if runtime.raptor.stderr:
                     # TODO(#229): Fetch actual stderr file.
                     # Note that all of the logging output goes to stderr, it seems,
                     # so we shouldn't necessarily consider it an error level event.
-                    logger.debug(runtime.scheduler.stderr)  # TODO(#108,#229): Receive report of work handled by Master.
+                    logger.debug(runtime.raptor.stderr)  # TODO(#108,#229): Receive report of work handled by Master.
 
             # Note: there are no documented exceptions or errors to check for,
             # programmatically. Some issues encountered during shutdown will be
@@ -1641,7 +1641,7 @@ def _describe_legacy_task(item: scalems.workflow.Task, pre_exec: list) -> rp.Tas
     return task_description
 
 
-def _describe_raptor_task(item: scalems.workflow.Task, scheduler: str, pre_exec: list) -> rp.TaskDescription:
+def _describe_raptor_task(item: scalems.workflow.Task, raptor_id: str, pre_exec: list) -> rp.TaskDescription:
     """Derive a RADICAL Pilot TaskDescription from a scalems workflow item.
 
     The TaskDescription will be submitted to the named *scheduler*,
@@ -1658,7 +1658,7 @@ def _describe_raptor_task(item: scalems.workflow.Task, scheduler: str, pre_exec:
         # This value is currently ignored, but must be set.
     )
     task_description.uid = item.uid()
-    task_description.scheduler = str(scheduler)
+    task_description.raptor_id = str(raptor_id)
     # Example work would be the JSON serialized form of the following dictionary.
     # {'mode': 'call',
     #  'cores': 1,
@@ -1699,7 +1699,7 @@ async def submit(
     item: scalems.workflow.Task,
     task_manager: rp.TaskManager,
     pre_exec: list,
-    scheduler: typing.Optional[str] = None,
+    raptor_id: typing.Optional[str] = None,
 ) -> asyncio.Task:
     """Dispatch a WorkflowItem to be handled by RADICAL Pilot.
 
@@ -1740,7 +1740,7 @@ async def submit(
         task_manager: A `radical.pilot.TaskManager` instance
             through which the task should be submitted.
         pre_exec: :py:data:`radical.pilot.Task.pre_exec` prototype.
-        scheduler (str): The string name of the "scheduler," corresponding to
+        raptor_id (str): The string name of the "scheduler," corresponding to
             the UID of a Task running a rp.raptor.Master (if Raptor is enabled).
 
     Returns:
@@ -1760,29 +1760,29 @@ async def submit(
     """
 
     # TODO: Optimization: skip tasks that are already done (cached results available).
-    def scheduler_is_ready(scheduler):
+    def raptor_is_ready(raptor_id):
         return (
-            isinstance(scheduler, str) and len(scheduler) > 0 and isinstance(task_manager.get_tasks(scheduler), rp.Task)
+            isinstance(raptor_id, str) and len(raptor_id) > 0 and isinstance(task_manager.get_tasks(raptor_id), rp.Task)
         )
 
     subprocess_type = TypeIdentifier(("scalems", "subprocess", "SubprocessTask"))
     submitted_type = item.description().type()
     if submitted_type == subprocess_type:
-        if scheduler is not None:
+        if raptor_id is not None:
             raise DispatchError("Raptor not yet supported for scalems.executable.")
         rp_task_description = _describe_legacy_task(item, pre_exec=pre_exec)
     elif configuration().enable_raptor:
-        if scheduler_is_ready(scheduler):
+        if raptor_is_ready(raptor_id):
             # We might want a contextvars.Context to hold the current rp.Master instance name.
-            rp_task_description = _describe_raptor_task(item, scheduler, pre_exec=pre_exec)
+            rp_task_description = _describe_raptor_task(item, raptor_id, pre_exec=pre_exec)
         else:
-            raise APIError("Caller must provide the UID of a submitted *scheduler* task.")
+            raise APIError("Caller must provide the UID of a submitted *raptor* task.")
     else:
         raise APIError(f"Cannot dispatch {submitted_type}.")
 
     # TODO(#249): A utility function to move slow blocking RP calls to a separate thread.
     #  Compartmentalize TaskDescription -> rp_task_watcher in a separate utility function.
-    task = task_manager.submit_tasks(rp_task_description)
+    (task,) = task_manager.submit_tasks([rp_task_description])
 
     rp_task_watcher = await rp_task(rptask=task)
 
@@ -1930,7 +1930,7 @@ async def subprocess_to_rp_task(
         mode=rp.TASK_EXECUTABLE,
     )
     if configuration().enable_raptor:
-        subprocess_dict["scheduler"] = dispatcher.runtime.scheduler.uid
+        subprocess_dict["scheduler"] = dispatcher.runtime.raptor.uid
     # Capturing stdout/stderr is a potentially unusual or unexpected behavior for
     # a Python function runner, and may collide with user assumptions or native
     # behaviors of third party tools. We will specify distinctive names for the RP
@@ -1971,7 +1971,7 @@ async def subprocess_to_rp_task(
     pilot_cores = rm_info["requested_cores"]
     # TODO: Account for Worker cores.
     if configuration().enable_raptor:
-        raptor_task: rp.Task = dispatcher.runtime.scheduler
+        raptor_task: rp.Task = dispatcher.runtime.raptor
         raptor_cores = raptor_task.description["ranks"] * raptor_task.description["cores_per_rank"]
     else:
         raptor_cores = 0

--- a/tests/test_raptor_utilities.py
+++ b/tests/test_raptor_utilities.py
@@ -16,8 +16,8 @@ import pytest
 
 import scalems
 from scalems.radical.raptor import ClientWorkerRequirements
-from scalems.radical.raptor import MasterTaskConfiguration
-from scalems.radical.raptor import ScaleMSMaster
+from scalems.radical.raptor import RaptorConfiguration
+from scalems.radical.raptor import ScaleMSRaptor
 from scalems.radical.raptor import ScaleMSWorker
 from scalems.radical.raptor import WorkerDescription
 
@@ -42,7 +42,7 @@ else:
 
 @pytest.mark.experimental
 def test_master_configuration_details(rp_venv):
-    """Test the details needed to launch the master script.
+    """Test the details needed to launch the raptor script.
 
     WARNING: This test is incomplete. We can't actually create a raptor.Master easily,
     but we can check its bits and pieces. This test mostly checks function signatures
@@ -60,7 +60,7 @@ def test_master_configuration_details(rp_venv):
     # Note that the Worker launch has unspecified results if the `named_env`
     # does not exist and is not scheduled to be created with `prepare_env`.
     # However, we are not currently using `named_env`. See #90.
-    configuration = MasterTaskConfiguration(
+    configuration = RaptorConfiguration(
         worker=ClientWorkerRequirements(
             named_env="scalems_test_ve", cpu_processes=worker_processes, gpus_per_process=gpus_per_process
         ),
@@ -68,18 +68,18 @@ def test_master_configuration_details(rp_venv):
     )
     # Note: *named_env* is unused, pending work on #90 and others.
 
-    conf_dict: scalems.radical.raptor._MasterTaskConfigurationDict = dataclasses.asdict(configuration)
-    configuration = MasterTaskConfiguration.from_dict(conf_dict)
+    conf_dict: scalems.radical.raptor._RaptorConfigurationDict = dataclasses.asdict(configuration)
+    configuration = RaptorConfiguration.from_dict(conf_dict)
     assert configuration.versioned_modules == list(versioned_modules)
     assert configuration.worker.named_env == "scalems_test_ve"
 
     encoded = json.dumps(configuration, default=object_encoder, indent=2)
-    configuration = scalems.radical.raptor.MasterTaskConfiguration.from_dict(json.loads(encoded))
+    configuration = scalems.radical.raptor.RaptorConfiguration.from_dict(json.loads(encoded))
     assert configuration.versioned_modules == [list(module_spec) for module_spec in versioned_modules]
     assert configuration.worker.named_env == "scalems_test_ve"
 
     with pytest.warns(match="raptor.Master base class"):
-        master = ScaleMSMaster(configuration)
+        master = ScaleMSRaptor(configuration)
     with master.configure_worker(configuration.worker) as worker_configs:
         assert len(worker_configs) == num_workers
         for descr in worker_configs:

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -90,12 +90,12 @@ async def test_raptor_master(pilot_description, rp_venv):
             assert isinstance(dispatcher, scalems.radical.runtime.RPDispatchingExecutor)
             logger.debug(f"test_raptor_master Session is {repr(dispatcher.runtime.session)}")
 
-            # Bypass the scalems machinery and submit an instruction directly to the master task.
+            # Bypass the scalems machinery and submit an instruction directly to the raptor task.
             # TODO: Use scalems.radical.runtime.submit()
-            scheduler: rp.Task = dispatcher.runtime.scheduler
+            raptor: rp.Task = dispatcher.runtime.raptor
             hello_command_description = rp.TaskDescription(
                 from_dict={
-                    "scheduler": scheduler.uid,
+                    "raptor": raptor.uid,
                     "mode": scalems.radical.raptor.CPI_MESSAGE,
                     "metadata": scalems.messages.HelloCommand().encode(),
                     "uid": f"command-hello-{scalems.identifiers.EphemeralIdentifier()}",
@@ -111,7 +111,7 @@ async def test_raptor_master(pilot_description, rp_venv):
 
             stop_command_description = rp.TaskDescription(
                 from_dict={
-                    "scheduler": scheduler.uid,
+                    "raptor": raptor.uid,
                     "mode": scalems.radical.raptor.CPI_MESSAGE,
                     "metadata": scalems.messages.Control.create("stop").encode(),
                     "uid": f"command-stop--{scalems.identifiers.EphemeralIdentifier()}",
@@ -127,18 +127,18 @@ async def test_raptor_master(pilot_description, rp_venv):
                 asyncio.to_thread(stop_task.wait, state=rp.FINAL, timeout=timeout), name="stop-watcher"
             )
 
-            scheduler_watcher = asyncio.create_task(
-                asyncio.to_thread(scheduler.wait, state=rp.FINAL, timeout=timeout), name="master-watcher"
+            raptor_watcher = asyncio.create_task(
+                asyncio.to_thread(raptor.wait, state=rp.FINAL, timeout=timeout), name="raptor-watcher"
             )
-            # If master task fails, stop-watcher will never complete.
+            # If raptor task fails, stop-watcher will never complete.
             done, pending = await asyncio.wait(
-                (stop_watcher, scheduler_watcher), timeout=timeout, return_when=asyncio.FIRST_COMPLETED
+                (stop_watcher, raptor_watcher), timeout=timeout, return_when=asyncio.FIRST_COMPLETED
             )
 
-            if scheduler_watcher not in done:
-                await asyncio.wait_for(scheduler_watcher, timeout=10)
-            logger.debug(f"scheduler-task state: {scheduler.state}")
-            if scheduler.state == rp.DONE and stop_watcher in pending:
+            if raptor_watcher not in done:
+                await asyncio.wait_for(raptor_watcher, timeout=10)
+            logger.debug(f"raptor-task state: {raptor.state}")
+            if raptor.state == rp.DONE and stop_watcher in pending:
                 # Waiting longer doesn't seem to help.
                 # logger.debug("Waiting a little longer for the stop task to wrap up.")
                 # await asyncio.wait_for(stop_watcher, timeout=timeout)
@@ -154,7 +154,7 @@ async def test_raptor_master(pilot_description, rp_venv):
                 stop_watcher.cancel()
             logger.debug(f"stop-task state: {stop_task.state}")
 
-            assert scheduler.state == rp.DONE
+            assert raptor.state == rp.DONE
 
     assert hello_state == rp.DONE
     assert hello_task.stdout == repr(scalems.radical.raptor.backend_version)
@@ -165,7 +165,7 @@ async def test_raptor_master(pilot_description, rp_venv):
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.asyncio
 async def test_worker(pilot_description, rp_venv):
-    """Launch the master script and execute a trivial workflow."""
+    """Launch the raptor script and execute a trivial workflow."""
 
     if rp_venv is None:
         # Be sure to provision the venv.
@@ -208,12 +208,12 @@ async def test_worker(pilot_description, rp_venv):
             task_uid = "add_item.scalems-test-worker"
 
             # Submit a raptor task
-            # Bypass the scalems machinery and submit an instruction directly to the master task.
+            # Bypass the scalems machinery and submit an instruction directly to the raptor task.
             # TODO: Use scalems.radical.runtime.submit()
-            scheduler: rp.Task = dispatcher.runtime.scheduler
+            raptor: rp.Task = dispatcher.runtime.raptor
 
             add_item_task_description = rp.TaskDescription()
-            add_item_task_description.scheduler = scheduler.uid
+            add_item_task_description.raptor = raptor.uid
             add_item_task_description.uid = task_uid
             add_item_task_description.cpu_processes = 1
             add_item_task_description.cpu_process_type = (rp.SERIAL,)
@@ -275,7 +275,7 @@ async def test_worker(pilot_description, rp_venv):
 #     # (RCT work in progress: https://github.com/radical-cybertools/radical.pilot/tree/feature/sandboxes
 #     # slated for merge in 2021 Q2 to support `sandbox://` URIs).
 #
-#     # define a raptor.scalems master and launch it within the pilot
+#     # define a raptor.scalems raptor and launch it within the pilot
 #     pwd   = os.path.dirname(__file__)
 #     td    = rp.TaskDescription(
 #             {
@@ -288,7 +288,7 @@ async def test_worker(pilot_description, rp_venv):
 #             })
 #     scheduler = tmgr.submit_tasks(td)
 #
-#     # define raptor.scalems tasks and submit them to the master
+#     # define raptor.scalems tasks and submit them to the raptor
 #     tds = list()
 #     for i in range(2):
 #         uid  = 'scalems.%06d' % i
@@ -322,7 +322,7 @@ async def test_worker(pilot_description, rp_venv):
 #     # wait for *those* tasks to complete and report results
 #     tmgr.wait_tasks(uids=[t.uid for t in tasks])
 #
-#     # Cancel the master.
+#     # Cancel the raptor.
 #     tmgr.cancel_tasks(uids=scheduler.uid)
 #     # Cancel blocks until the task is done so the following wait it currently redundant,
 #     # but there is a ticket open to change this behavior.


### PR DESCRIPTION
Use "raptor", "raptor_id", and "ScaleMSRaptor" instead of "master" and "scheduler" terms.

Fixes #333 