### PR TITLE
Tweak imports in scalems.radical.raptor module.

### DIFF
--- a/src/scalems/radical/raptor/__init__.py
+++ b/src/scalems/radical/raptor/__init__.py
@@ -297,13 +297,9 @@ if typing.TYPE_CHECKING:
 # We import rp before `logging` to avoid warnings when rp monkey-patches the
 # logging module. This `try` suite helps prevent auto-code-formatters from
 # rearranging the import order of built-in versus third-party modules.
-try:
-    import radical.pilot as rp
-except ImportError:
-    warnings.warn("RADICAL Pilot installation not found.")
+import radical.pilot as rp
 
 import scalems.exceptions
-import scalems.radical
 import scalems.messages
 import scalems.file as _file
 import scalems.store as _store

--- a/src/scalems/radical/runtime.py
+++ b/src/scalems/radical/runtime.py
@@ -190,7 +190,6 @@ import scalems.execution
 import scalems.file
 import scalems.invocation
 import scalems.messages
-import scalems.radical
 import scalems.radical.raptor
 import scalems.store
 import scalems.subprocess
@@ -204,7 +203,6 @@ from scalems.exceptions import ScaleMSError
 from .raptor import raptor_input
 from ..store import FileStore
 from ..execution import AbstractWorkflowUpdater
-from ..execution import RuntimeManager
 from ..identifiers import EphemeralIdentifier
 from ..identifiers import TypeIdentifier
 
@@ -959,7 +957,7 @@ async def get_pilot_resources(pilot: rp.Pilot):
         return rm_info.copy()
 
 
-class RPDispatchingExecutor(RuntimeManager):
+class RPDispatchingExecutor(scalems.execution.RuntimeManager):
     """Client side manager for work dispatched through RADICAL Pilot.
 
     Configuration points:


### PR DESCRIPTION
* Importing parent module is unnecessary and inappropriate.
* Remove `try` block around `rp` import: The module cannot successfully import without successful import of `radical.pilot`.