### PR TITLE
Clean up Pilot acquisition.

### DIFF
--- a/src/scalems/execution.py
+++ b/src/scalems/execution.py
@@ -198,7 +198,7 @@ class RuntimeDescriptor:
             pass
 
     def __init__(self):
-        self.private_name = "_runtime_state"
+        self.private_name = "_runtime_session"
 
 
 _BackendT = typing.TypeVar("_BackendT")
@@ -222,6 +222,7 @@ class RuntimeManager(typing.Generic[_BackendT], abc.ABC):
 
     _command_queue: asyncio.Queue
     _dispatcher_lock: asyncio.Lock
+    _loop: asyncio.AbstractEventLoop
     _queue_runner_task: typing.Union[None, asyncio.Task] = None
 
     runtime = RuntimeDescriptor()
@@ -287,8 +288,7 @@ class RuntimeManager(typing.Generic[_BackendT], abc.ABC):
         """
         logger.debug(f"Null CPI handler received command {command}.")
 
-    @staticmethod
-    def runtime_shutdown(runtime):
+    def runtime_shutdown(self, runtime):
         """Shutdown hook for runtime facilities.
 
         Called while exiting the context manager. Allows specialized handling of

--- a/tests/test_radical_runtime.py
+++ b/tests/test_radical_runtime.py
@@ -1,11 +1,12 @@
 """Test the scalems.radical.Runtime state object."""
+import asyncio
 import logging
-import typing
 import warnings
 
 import pytest
 import radical.pilot as rp
 
+import scalems.radical.runtime
 from scalems.exceptions import APIError
 from scalems.radical.runtime import RuntimeSession
 
@@ -13,153 +14,64 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+@pytest.mark.asyncio
+async def test_pilot_resources(rp_runtime: scalems.radical.runtime.RuntimeSession, event_loop):
+    rm_info = await asyncio.wait_for(rp_runtime.resources, timeout=180)
+    assert rm_info.get("requested_cores", 0) >= 1
+
+
 @pytest.mark.exhaustive
-def test_runtime_normal_instance(rp_task_manager, pilot_description):
-    """Set the Runtime.pilot from an rp.Pilot instance."""
+@pytest.mark.asyncio
+async def test_runtime_mismatch(pilot_description, event_loop, rp_configuration):
+    """Make sure we catch some invalid configurations and still shut down cleanly."""
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
         warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
         warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
 
-        session: rp.Session = rp_task_manager.session
+        rp_session = await event_loop.run_in_executor(None, rp.Session)
 
-        state = RuntimeSession(session=session)
-
-        state.task_manager(rp_task_manager)
-
-        # We only expect one pilot
-        pilot: rp.Pilot = rp_task_manager.get_pilots()[0]
-        # We get a dictionary...
-        # assert isinstance(pilot, rp.Pilot)
-        # But it looks like it has the pilot id in it.
-        pilot_uid = typing.cast(dict, pilot)["uid"]
-        pmgr_uid = typing.cast(dict, pilot)["pmgr"]
-        pmgr: rp.PilotManager = session.get_pilot_managers(pmgr_uids=pmgr_uid)
-        assert isinstance(pmgr, rp.PilotManager)
-
-        state.pilot_manager(pmgr)
-
-        pilot = pmgr.get_pilots(uids=pilot_uid)
-        assert isinstance(pilot, rp.Pilot)
-        state.pilot(pilot)
-
-
-@pytest.mark.exhaustive
-def test_runtime_normal_uid(rp_task_manager, pilot_description):
-    """Set the Runtime.pilot from the UID obtained from the task_manager."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
-
-        session: rp.Session = rp_task_manager.session
-
-        state = RuntimeSession(session=session)
-
-        state.task_manager(rp_task_manager.uid)
-
-        # We only expect one pilot
-        pilot: rp.Pilot = rp_task_manager.get_pilots()[0]
-        # We get a dictionary...
-        # assert isinstance(pilot, rp.Pilot)
-        # But it looks like it has the pilot id in it.
-        pilot_uid = typing.cast(dict, pilot)["uid"]
-
-        # It is an error to set a Pilot before the PilotManager has been set.
-        with pytest.raises(APIError):
-            state.pilot(pilot_uid)
-
-        pmgr_uid = typing.cast(dict, pilot)["pmgr"]
-
-        state.pilot_manager(pmgr_uid)
-
-        state.pilot(pilot_uid)
-
-
-@pytest.mark.exhaustive
-def test_runtime_bad_uid(pilot_description):
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
-
-        session = rp.Session()
-
-        with session:
-            state = RuntimeSession(session=session)
-
-            with pytest.raises(ValueError):
-                state.task_manager("spam")
-
-            tmgr = rp.TaskManager(session=session)
-            state.task_manager(tmgr)
-
-            with pytest.raises(ValueError):
-                state.pilot_manager("spam")
-
-            pmgr = rp.PilotManager(session=session)
-            state.pilot_manager(pmgr)
-
-            with pytest.raises(ValueError):
-                state.pilot_manager("spam")
-
-            tmgr.close()
-            pmgr.close()
-
-        assert session.closed
-
-
-@pytest.mark.exhaustive
-def test_runtime_mismatch(pilot_description):
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.task_manager")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.db.database")
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="radical.pilot.session")
-
-        session = rp.Session()
-
-        with session:
-            original_pmgr = rp.PilotManager(session=session)
-            pilot = original_pmgr.submit_pilots(rp.PilotDescription(pilot_description))
-            original_tmgr = rp.TaskManager(session=session)
+        with rp_session:
+            original_pmgr = await event_loop.run_in_executor(None, rp.PilotManager, rp_session)
+            pilot = await event_loop.run_in_executor(
+                None, original_pmgr.submit_pilots, rp.PilotDescription(pilot_description)
+            )
+            original_tmgr = await event_loop.run_in_executor(None, rp.TaskManager, rp_session)
             original_tmgr.add_pilots(pilot)
 
-        assert session.closed
+        assert rp_session.closed
         # This assertion may not be true:
         # assert pilot.state in rp.FINAL
         # Note that Pilot and other components may still be shutting down, but the
         # intention is that, from this point, pmgr, pilot, and tmgr are now "stale".
 
-        session = rp.Session()
+        rp_session = await event_loop.run_in_executor(None, rp.Session)
 
-        with session:
-            state = RuntimeSession(session=session)
+        with rp_session:
+            runtime_session = RuntimeSession(session=rp_session, loop=event_loop, configuration=rp_configuration)
 
             with pytest.raises(APIError):
-                state.task_manager(original_tmgr)
+                runtime_session.task_manager(original_tmgr)
             original_tmgr.close()
 
-            tmgr = rp.TaskManager(session=session)
-            state.task_manager(tmgr)
+            tmgr = rp.TaskManager(session=rp_session)
+            runtime_session.task_manager(tmgr)
 
             with pytest.raises(APIError):
-                state.pilot_manager(original_pmgr)
+                runtime_session.pilot_manager(original_pmgr)
             original_pmgr.close()
 
-            pmgr = rp.PilotManager(session=session)
-            state.pilot_manager(pmgr)
+            pmgr = rp.PilotManager(session=rp_session)
+            runtime_session.pilot_manager(pmgr)
 
-            # The UID will not resolve in the stored PilotManager.
-            with pytest.raises(ValueError):
-                state.pilot(pilot.uid)
+            new_pilot = runtime_session.pilot()
+            assert pilot.uid != new_pilot.uid
 
-            # The Pilot is detectably invalid.
-            with pytest.raises(APIError):
-                state.pilot(pilot)
+            runtime_session.close()
 
             # Even here, the old Pilot may still be in 'PMGR_ACTIVE_PENDING'
             if pilot.state not in rp.FINAL:
                 pilot.cancel()
             tmgr.close()
             pmgr.close()
-        assert session.closed
+        assert rp_session.closed

--- a/tests/test_rp_exec.py
+++ b/tests/test_rp_exec.py
@@ -59,7 +59,7 @@ else:
 
 
 @pytest.mark.asyncio
-async def test_rp_future(rp_task_manager):
+async def test_rp_future(rp_runtime):
     """Check our Future implementation for RP at a low level.
 
     Fulfill the asyncio.Future protocol for a rp.Task wrapper object. The wrapper
@@ -67,7 +67,7 @@ async def test_rp_future(rp_task_manager):
     """
     timeout = 120
 
-    tmgr = rp_task_manager
+    tmgr = rp_runtime.task_manager()
 
     task_description_dict = dict(
         executable="/bin/bash",


### PR DESCRIPTION
* Clarify some naming.
* Consolidate logic from conftest and elsewhere for creation and
  maintenance of the scalems.radical.runtime.RuntimeSession.
* Use a creation function to provide RuntimeSession with an asyncio
  event loop.
* Update the testing framework to use the new encapsulated
  RuntimeSession lifetime management.

Note: We need to interact with the RuntimeSession in the main thread
whenever possible. Let the RuntimeSession dispatch slow rp UI calls to
other threads as needed and appropriate.

TODO(#334):
* Avoid using an extra thread. Use a Pilot callback and asyncio logic to
  get Pilot runtime resources dict.
* When we use to_thread for rp UI, we MUST schedule watcher that
  makes sure the thread is freed a reasonable amount of time after
  canceling the asyncio Future wrapper.

TODO(#335):
* Break up the scalems.radical.runtime module for the major classes and
  their supporting functions and module variables.