### PR TITLE
Pin gromacs release version in tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         # will assign a random free host port
         - 27017/tcp
     env:
-      GROMACS: release-2023
+      GROMACS: v2023.2
       GMXAPI: "gmxapi"
       GMX_MPI: "ON"
 
@@ -182,7 +182,7 @@ jobs:
         # will assign a random free host port
         - 27017/tcp
     env:
-      GROMACS: release-2023
+      GROMACS: v2023.2
       GMXAPI: "gmxapi"
       GMX_MPI: "ON"
 


### PR DESCRIPTION
Improve build caching in GitHub Actions by only building tagged releases.