### PR TITLE
Cap RP version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "dill",
     "mpi4py",
     "packaging",
-    "radical.pilot >= 1.33",
+    "radical.pilot < 1.36",
     "typing_extensions"
 ]
 
@@ -32,7 +32,7 @@ test = [
     "pytest >= 6.1.2 ",
     "pytest-asyncio >= 0.14",
     "pytest-env",
-    "radical.pilot >= 1.33"
+    "radical.pilot < 1.36"
 ]
 
 [project.scripts]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -17,7 +17,7 @@ ntplib
 pylint
 pymongo<4.0
 python-hostlist
-radical.pilot>=1.33
+radical.pilot<1.36
 setproctitle
 tox>=2.0
 # Raptor MPI worker requirements


### PR DESCRIPTION
Temporarily avoid radical.pilot 1.36, pending resolution of https://github.com/radical-cybertools/radical.pilot/issues/3001

Revert this commit when resolved.

Ref #379.