### PR TITLE
Prune some unused code.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ test = [
     "radical.pilot < 1.36"
 ]
 
-[project.scripts]
-scalems_raptor = "scalems.radical.raptor:raptor"
-
 [tool.setuptools]
 zip-safe = false
 

--- a/src/scalems/radical/raptor/__main__.py
+++ b/src/scalems/radical/raptor/__main__.py
@@ -1,6 +1,8 @@
 """Entry point for the Master Task role of the scalems.radical.raptor module.
 
-An alternative to the setuptools generated entry-point script (:file:`scalems_rp_master`).
+Executes :py:func:`scalems.radical.raptor.raptor()`.
+
+Records ``scalems`` `logging` messages to :file:`scalems.radical.raptor.log`.
 """
 
 import sys


### PR DESCRIPTION
We no longer use the `scalems_raptor` entry-point script. Instead, we just use a module `__main__` for the Raptor master task: `<python> -m scalems.radical.raptor <config>.json`